### PR TITLE
adapted to kubernetes scheduling plugin api

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -10,12 +10,14 @@ import (
 
 	"code.google.com/p/goprotobuf/proto"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	algorithm "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	plugin "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	log "github.com/golang/glog"
 	"github.com/mesos/mesos-go/mesos"
@@ -217,6 +219,9 @@ type KubernetesScheduler struct {
 	// and the invoking the pob registry interfaces.
 	*sync.RWMutex
 
+	// easy access to etcd ops
+	tools.EtcdHelper
+
 	// Mesos context.
 	executor    *mesos.ExecutorInfo
 	Driver      mesos.SchedulerDriver
@@ -248,9 +253,10 @@ type KubernetesScheduler struct {
 }
 
 // New create a new KubernetesScheduler
-func New(executor *mesos.ExecutorInfo, scheduleFunc PodScheduleFunc, client *client.Client) *KubernetesScheduler {
+func New(executor *mesos.ExecutorInfo, scheduleFunc PodScheduleFunc, client *client.Client, helper tools.EtcdHelper) *KubernetesScheduler {
 	return &KubernetesScheduler{
 		new(sync.RWMutex),
+		helper,
 		executor,
 		nil,
 		nil,
@@ -718,6 +724,13 @@ func (k *KubernetesScheduler) UpdatePod(pod api.Pod) error {
 // Delete an existing pod.
 func (k *KubernetesScheduler) DeletePod(podID string) error {
 	log.V(2).Infof("Delete pod '%s'\n", podID)
+
+	if err := k.unbindPod(podID); err != nil {
+		log.Warningf("Failed to unbind pod '%s' from etcd: %v", podID, err)
+		// proceed to attempt task removal anyway since we may have already
+		// launched a task for this pod but the binding may have failed
+	}
+	
 	taskId, exists := k.podToTask[podID]
 	if !exists {
 		return fmt.Errorf("Could not resolve pod '%s' to task id", podID)
@@ -730,6 +743,65 @@ func (k *KubernetesScheduler) DeletePod(podID string) error {
 
 	return fmt.Errorf("Cannot kill pod '%s': pod not found", podID)
 }
+
+// HACK copied from pkg.registry.etcd; should not need to do this once our scheduler is
+// refactored to use the default kubernetes master pod registry
+func (k *KubernetesScheduler) unbindPod(podID string) error {
+	var pod api.Pod
+	podKey := makePodKey(podID)
+	err := k.ExtractObj(podKey, &pod, false)
+	if tools.IsEtcdNotFound(err) {
+		return apierrors.NewNotFound("pod", podID)
+	}
+	if err != nil {
+		return err
+	}
+	// First delete the pod, so a scheduler doesn't notice it getting removed from the
+	// machine and attempt to put it somewhere.
+	err = k.Delete(podKey, true)
+	if tools.IsEtcdNotFound(err) {
+		return apierrors.NewNotFound("pod", podID)
+	}
+	if err != nil {
+		return err
+	}
+	machine := pod.DesiredState.Host
+	if machine == "" {
+		// Pod was never scheduled anywhere, just return.
+		return nil
+	}
+	// Next, remove the pod from the machine atomically.
+	contKey := makeContainerKey(machine)
+	return k.AtomicUpdate(contKey, &api.ContainerManifestList{}, func(in interface{}) (interface{}, error) {
+		manifests := in.(*api.ContainerManifestList)
+		newManifests := make([]api.ContainerManifest, 0, len(manifests.Items))
+		found := false
+		for _, manifest := range manifests.Items {
+			if manifest.ID != podID {
+				newManifests = append(newManifests, manifest)
+			} else {
+				found = true
+			}
+		}
+		if !found {
+			// This really shouldn't happen, it indicates something is broken, and likely
+			// there is a lost pod somewhere.
+			// However it is "deleted" so log it and move on
+			log.Infof("Couldn't find: %s in %#v", podID, manifests)
+		}
+		manifests.Items = newManifests
+		return manifests, nil
+	})
+}
+// needed by unbindPod
+func makePodKey(podID string) string {
+	return "/registry/pods/" + podID
+}
+// needed by unbindPod
+func makeContainerKey(machine string) string {
+	return "/registry/hosts/" + machine + "/kubelet"
+}
+
 
 func (k *KubernetesScheduler) WatchPods(resourceVersion uint64, filter func(*api.Pod) bool) (watch.Interface, error) {
 	return nil, nil


### PR DESCRIPTION
Deploying a pod JSON works again, though I get an error at the client side (even though the pod deploys OK):

```
[root@mesos-dev k8s-mesos]# curl -L http://localhost:8080/api/v1beta1/pods -XPOST -d @nginx.json
{"kind":"Status","creationTimestamp":null,"apiVersion":"v1beta1","status":"failure","message":"Could not resolve pod 'nginx-id-01' to task id","code":500}
```
