### PR TITLE
rebase to kubernetes v0.5x+

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -12,6 +12,8 @@ To get started with development you'll need to install some prerequisites:
 * Install protobuf and Go
 * Install [godep][2]
 
+The steps for installing prerequisites assume that you are logged in as `root`, otherwise you will need to insert `sudo` where appropriate.
+
 #### Debian
 
 ```shell

--- a/Godeps/.gitignore
+++ b/Godeps/.gitignore
@@ -1,0 +1,1 @@
+_workspace

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -27,166 +27,171 @@
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/api",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/client",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/constraint",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/conversion",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/health",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/httplog",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/labels",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/master",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/binding",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/controller",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/endpoint",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/etcd",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/minion",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/pod",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/runtime",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/service",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/tools",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/util",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/version",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/volume",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/watch",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler",
-			"Comment": "v0.4.4",
-			"Rev": "efd443bcd6f005566daa85da0a5f0b633b40d4e3"
+			"Comment": "v0.5.4",
+			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-etcd/etcd",
 			"Comment": "v0.2.0-rc1-120-g23142f6",
 			"Rev": "23142f6773a676cc2cae8dd0cb90b2ea761c853f"
 		},
-                {
-                        "ImportPath": "github.com/elazarl/go-bindata-assetfs",
-                        "Rev": "ae4665cf2d188c65764c73fe4af5378acc549510"
-                },
+		{
+			"ImportPath": "github.com/elazarl/go-bindata-assetfs",
+			"Rev": "ae4665cf2d188c65764c73fe4af5378acc549510"
+		},
+		{
+			"ImportPath": "github.com/emicklei/go-restful",
+			"Comment": "v1.1.2-34-gcb26ade",
+			"Rev": "cb26adeb9644200cb4ec7b32be31e024696e8d00"
+		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
-			"Comment": "0.2.1-241-g0dbb508",
-			"Rev": "0dbb508e94dd899a6743d035d8f249c7634d26da"
+			"Comment": "0.2.1-267-g15d2c6e",
+			"Rev": "15d2c6e3eb670c545d0af0604d7f9aff3871af04"
 		},
 		{
 			"ImportPath": "github.com/golang/glog",
-			"Rev": "d1c4472bf2efd3826f2b5bdcc02d8416798d678c"
+			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info",
-			"Comment": "0.4.0",
-			"Rev": "5a6d06c02600b1e57e55a9d9f71dbac1bfc9fe6c"
+			"Comment": "0.5.0",
+			"Rev": "8c4f650e62f096710da794e536de86e34447fca9"
 		},
 		{
 			"ImportPath": "github.com/mesos/mesos-go/mesos",
@@ -195,6 +200,14 @@
 		{
 			"ImportPath": "github.com/skratchdot/open-golang/open",
 			"Rev": "ba570a111973b539baf23c918213059543b5bb6e"
+		},
+		{
+			"ImportPath": "github.com/spf13/cobra",
+			"Rev": "b1e90a7943957b51bb96a13b44b844475bcf95c0"
+		},
+		{
+			"ImportPath": "github.com/spf13/pflag",
+			"Rev": "463bdc838f2b35e9307e91d480878bda5fff7232"
 		},
 		{
 			"ImportPath": "gopkg.in/v1/yaml",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -27,143 +27,143 @@
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/api",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/client",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/constraint",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/conversion",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/health",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/httplog",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/labels",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/master",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/binding",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/controller",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/endpoint",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/etcd",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/minion",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/pod",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/runtime",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/service",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/tools",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/util",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/version",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/volume",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/pkg/watch",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler",
-			"Comment": "v0.5.4",
-			"Rev": "a589f85a45d33cabb5562b84d6633815f8c3579b"
+			"Comment": "v0.6.2",
+			"Rev": "729fde276613eedcd99ecf5b93f095b8deb64eb4"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-etcd/etcd",
@@ -176,8 +176,8 @@
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful",
-			"Comment": "v1.1.2-34-gcb26ade",
-			"Rev": "cb26adeb9644200cb4ec7b32be31e024696e8d00"
+			"Comment": "v1.1.2-38-gab99062",
+			"Rev": "ab990627e3546d3c6c8ab45c4d887a3d66b1b6ab"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
@@ -208,6 +208,11 @@
 		{
 			"ImportPath": "github.com/spf13/pflag",
 			"Rev": "463bdc838f2b35e9307e91d480878bda5fff7232"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Comment": "null-214",
+			"Rev": "cbcac7bb8415db9b6cb4d1ebab1dc9afbd688b97"
 		},
 		{
 			"ImportPath": "gopkg.in/v1/yaml",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -189,7 +189,7 @@
 			"Rev": "5a6d06c02600b1e57e55a9d9f71dbac1bfc9fe6c"
 		},
 		{
-			"ImportPath": "github.com/mesos/mesos-go/mesos",
+			"ImportPath": "github.com/mesos/mesos-go",
 			"Rev": "9c6a968b270c50e35f99d6cf649a18521b76c18a"
 		},
 		{

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -189,7 +189,7 @@
 			"Rev": "5a6d06c02600b1e57e55a9d9f71dbac1bfc9fe6c"
 		},
 		{
-			"ImportPath": "github.com/mesos/mesos-go",
+			"ImportPath": "github.com/mesos/mesos-go/mesos",
 			"Rev": "9c6a968b270c50e35f99d6cf649a18521b76c18a"
 		},
 		{

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ KUBE_GO_PACKAGE	?= github.com/GoogleCloudPlatform/kubernetes
 
 K8S_CMD		:= \
                    ${KUBE_GO_PACKAGE}/cmd/kubecfg		\
-                   ${KUBE_GO_PACKAGE}/cmd/proxy
+                   ${KUBE_GO_PACKAGE}/cmd/kubectl		\
+                   ${KUBE_GO_PACKAGE}/cmd/kube-proxy
 FRAMEWORK_CMD	:= \
                    github.com/mesosphere/kubernetes-mesos/controller-manager		\
                    github.com/mesosphere/kubernetes-mesos/kubernetes-mesos		\

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,16 @@ WITH_MESOS_CGO_FLAGS :=  \
 
 endif
 
+FRAMEWORK_FLAGS := -v -x -tags '$(TAGS)'
+
+ifneq ($(STATIC),)
+FRAMEWORK_FLAGS += --ldflags '-extldflags "-static"'
+endif
+
+ifneq ($(WITH_RACE),)
+FRAMEWORK_FLAGS += -race
+endif
+
 export SHELL
 export KUBE_GO_PACKAGE
 
@@ -79,7 +89,7 @@ proxy: require-godep $(KUBE_GIT_VERSION_FILE)
 require-vendor:
 
 framework: require-godep
-	env $(WITH_MESOS_CGO_FLAGS) go install -v -x -tags '$(TAGS)' $${WITH_RACE:+-race} $(FRAMEWORK_CMD)
+	env $(WITH_MESOS_CGO_FLAGS) go install $(FRAMEWORK_FLAGS) $(FRAMEWORK_CMD)
 
 format: require-gopath
 	go fmt $(FRAMEWORK_CMD) $(FRAMEWORK_LIB)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ $ ./bin/kubernetes-mesos \
   -etcd_servers=http://${servicehost}:4001 \
   -executor_path=$(pwd)/bin/kubernetes-executor \
   -proxy_path=$(pwd)/bin/kube-proxy \
-  -portal_net=10.10.10.0/24
+  -portal_net=10.10.10.0/24 \
+  -mesos_user=root
 ```
 
 For simpler execution of `kubecfg`:

--- a/README.md
+++ b/README.md
@@ -55,12 +55,17 @@ $ cd $GOPATH # If you don't have one, create directory and set GOPATH accordingl
 $ mkdir -p src/github.com/mesosphere/kubernetes-mesos
 $ git clone https://github.com/mesosphere/kubernetes-mesos.git src/github.com/mesosphere/kubernetes-mesos
 $ cd src/github.com/mesosphere/kubernetes-mesos && godep restore
-$ go install github.com/GoogleCloudPlatform/kubernetes/cmd/{proxy,kubecfg}
+$ go install github.com/GoogleCloudPlatform/kubernetes/cmd/{kube-proxy,kubecfg,kubectl}
 $ go install github.com/mesosphere/kubernetes-mesos/kubernetes-{mesos,executor}
 $ go install github.com/mesosphere/kubernetes-mesos/controller-manager
 ```
 
 ### Start the framework
+
+**NETWORKING:** Kubernetes v0.5 introduced "Services v2" which follows a Service-per-IP model.
+A consequence of this is that you must identify CIDR subnet to the Kubernetes-Mesos master that may be used for allocating IP addresses for Kubernetes services (the `-portal_net` parameter).
+The value provided in the example below is purely for illustration and may need to be adjusted for your network.
+See the Kubernetes [release notes](https://github.com/GoogleCloudPlatform/kubernetes/releases/tag/v0.5) for additional details regarding the new Services model.
 
 The examples that follow assume that you are running the mesos-master, etcd, and the kubernetes-mesos framework on the same host, exposed on an IP address referred to hereafter as `${servicehost}`.
 If you are not running in a production setting then a single etcd instance will suffice.
@@ -84,7 +89,8 @@ $ ./bin/kubernetes-mesos \
   -mesos_master=${servicehost}:5050 \
   -etcd_servers=http://${servicehost}:4001 \
   -executor_path=$(pwd)/bin/kubernetes-executor \
-  -proxy_path=$(pwd)/bin/proxy
+  -proxy_path=$(pwd)/bin/kube-proxy \
+  -portal_net=10.10.10.0/24
 ```
 
 For simpler execution of `kubecfg`:

--- a/README.md
+++ b/README.md
@@ -53,16 +53,21 @@ Once the [prerequisites][7] have been installed you can build the project:
 $ cd $GOPATH # If you don't have one, create directory and set GOPATH accordingly.
 
 $ mkdir -p src/github.com/mesosphere/kubernetes-mesos
-$ git clone git@github.com:mesosphere/kubernetes-mesos.git src/github.com/mesosphere/kubernetes-mesos
+$ git clone https://github.com/mesosphere/kubernetes-mesos.git src/github.com/mesosphere/kubernetes-mesos
 $ cd src/github.com/mesosphere/kubernetes-mesos && godep restore
-$ go install github.com/GoogleCloudPlatform/kubernetes/cmd/{proxy,controller-manager}
-$ go install github.com/mesosphere/kubernetes-mesos/kubernetes-{mesos,executor}
+$ go install github.com/GoogleCloudPlatform/kubernetes/cmd/{proxy,kubecfg}
+$ go install github.com/mesosphere/kubernetes-mesos/kubernetes-{mesos,executor,controller-manager}
 ```
 
 ### Start the framework
 
+The examples that follow assume that you are running the mesos-master, etcd, and the kubernetes-mesos framework on the same host, exposed on an IP address referred to hereafter as `${servicehost}`.
+If you are not running in a production setting then a single etcd instance will suffice.
 To run etcd, see [github.com/coreos/etcd][6], or run it via docker:
+
 ```shell
+$ export servicehost=...  # IP address of the framework host
+
 $ sudo docker run -d --net=host coreos/etcd go-wrapper run \
    -advertise-client-urls=http://${servicehost}:4001 \
    -listen-client-urls=http://${servicehost}:4001 \

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ $ go install github.com/mesosphere/kubernetes-mesos/controller-manager
 
 ### Start the framework
 
-**NETWORKING:** Kubernetes v0.5 introduced "Services v2" which follows a Service-per-IP model.
-A consequence of this is that you must identify CIDR subnet to the Kubernetes-Mesos master that may be used for allocating IP addresses for Kubernetes services (the `-portal_net` parameter).
-The value provided in the example below is purely for illustration and may need to be adjusted for your network.
-See the Kubernetes [release notes](https://github.com/GoogleCloudPlatform/kubernetes/releases/tag/v0.5) for additional details regarding the new Services model.
+**NETWORKING:** Kubernetes v0.5 introduced "Services v2" which follows an IP-per-Service model.
+A consequence of this is that you must provide the Kubernetes-Mesos framework with a [CIDR][8] subnet that will be used for the allocation of IP addresses for Kubernetes services: the `-portal_net` parameter.
+Please keep this in mind when reviewing (and attempting) the example below - the CIDR subnet may need to be adjusted for your network.
+See the Kubernetes [release notes][9] for additional details regarding the new services model.
 
 The examples that follow assume that you are running the mesos-master, etcd, and the kubernetes-mesos framework on the same host, exposed on an IP address referred to hereafter as `${servicehost}`.
 If you are not running in a production setting then a single etcd instance will suffice.
@@ -378,3 +378,5 @@ $ go test github.com/mesosphere/kubernetes-mesos/kubernetes-mesos -v
 [5]: https://github.com/tools/godep
 [6]: https://github.com/coreos/etcd/releases/
 [7]: DEVELOP.md#prerequisites
+[8]: http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
+[9]: https://github.com/GoogleCloudPlatform/kubernetes/releases/tag/v0.5

--- a/controller-manager/controller-manager.go
+++ b/controller-manager/controller-manager.go
@@ -33,7 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
-	masterPkg "github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	kendpoint "github.com/GoogleCloudPlatform/kubernetes/pkg/service"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version/verflag"
@@ -43,10 +43,10 @@ import (
 )
 
 var (
-	port                 = flag.Int("port", masterPkg.ControllerManagerPort, "The port that the controller-manager's http service runs on")
+	port                 = flag.Int("port", ports.ControllerManagerPort, "The port that the controller-manager's http service runs on")
 	address              = util.IP(net.ParseIP("127.0.0.1"))
-	useHostPortEndpoints = flag.Bool("host_port_endpoints", true, "Map service endpoints to hostIP:hostPort instead of podIP:containerPort. Default true.")
 	clientConfig         = &client.Config{}
+	useHostPortEndpoints = flag.Bool("host_port_endpoints", true, "Map service endpoints to hostIP:hostPort instead of podIP:containerPort. Default true.")
 )
 
 func init() {

--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -240,7 +240,7 @@ Create a file named `frontend-controller.json`:
            "id": "frontendController",
            "containers": [{
              "name": "php-redis",
-             "image": "brendanburns/php-redis",
+             "image": "jdef/php-redis",
              "ports": [{"containerPort": 80, "hostPort": 31030}]
            }]
          }
@@ -259,7 +259,7 @@ $ bin/kubecfg -c examples/guestbook/frontend-controller.json create replicationC
 $ curl ${KUBERNETES_MASTER}/api/v1beta1/replicationControllers -XPOST -d@examples/guestbook/frontend-controller.json
 ID                   Image(s)                 Selector            Replicas
 ----------           ----------               ----------          ----------
-frontendController   brendanburns/php-redis   name=frontend       3
+frontendController   jdef/php-redis           name=frontend       3
 ```
 
 Once that's up you can list the pods in the cluster, to verify that the master, slaves and frontends are running:
@@ -271,9 +271,9 @@ ID                                     Image(s)                 Host            
 redis-master-2                         dockerfile/redis         10.132.189.243/10.132.189.243   name=redis-master                                            Running
 439c1c7c-6694-11e4-bd1f-04012f416701   jdef/redis-slave         10.132.189.242/10.132.189.242   name=redisslave,replicationController=redisSlaveController   Running
 439b7b2f-6694-11e4-bd1f-04012f416701   jdef/redis-slave         10.132.189.243/10.132.189.243   name=redisslave,replicationController=redisSlaveController   Running
-901eb1c1-6695-11e4-bd1f-04012f416701   brendanburns/php-redis   10.132.189.243/10.132.189.243   name=frontend,replicationController=frontendController       Running
-901edf34-6695-11e4-bd1f-04012f416701   brendanburns/php-redis   10.132.189.240/10.132.189.240   name=frontend,replicationController=frontendController       Running
-901e29a7-6695-11e4-bd1f-04012f416701   brendanburns/php-redis   10.132.189.242/10.132.189.242   name=frontend,replicationController=frontendController       Running
+901eb1c1-6695-11e4-bd1f-04012f416701   jdef/php-redis           10.132.189.243/10.132.189.243   name=frontend,replicationController=frontendController       Running
+901edf34-6695-11e4-bd1f-04012f416701   jdef/php-redis           10.132.189.240/10.132.189.240   name=frontend,replicationController=frontendController       Running
+901e29a7-6695-11e4-bd1f-04012f416701   jdef/php-redis           10.132.189.242/10.132.189.242   name=frontend,replicationController=frontendController       Running
 ```
 
 You will see a single redis master pod, two redis slaves, and three frontend pods.

--- a/examples/guestbook/frontend-controller.json
+++ b/examples/guestbook/frontend-controller.json
@@ -12,7 +12,7 @@
              "id": "frontendController",
              "containers": [{
                "name": "php-redis",
-               "image": "brendanburns/php-redis",
+               "image": "jdef/php-redis",
                "ports": [{"containerPort": 80, "hostPort": 31030}]
              }]
            }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -148,6 +148,11 @@ func (k *KubernetesExecutor) LaunchTask(driver mesos.ExecutorDriver, taskInfo *m
 				continue
 			}
 
+			// avoid sending back a running status while pod networking is down
+			if podnet, ok := info["net"]; !ok || podnet.State.Running == nil {
+				continue
+			}
+
 			log.V(2).Infof("Found pod info: '%v'", info)
 			data, err := json.Marshal(info)
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -19,8 +19,8 @@ const (
 )
 
 type kuberTask struct {
-	mesosTaskInfo     *mesos.TaskInfo
-	containerManifest *api.ContainerManifest
+	mesosTaskInfo *mesos.TaskInfo
+	podName       string
 }
 
 // KubernetesExecutor is an mesos executor that runs pods
@@ -31,9 +31,9 @@ type KubernetesExecutor struct {
 	driver     mesos.ExecutorDriver
 	registered bool
 	tasks      map[string]*kuberTask
-	pods       map[string]*kubelet.Pod
+	pods       map[string]*api.BoundPod
 	lock       sync.RWMutex
-	namespace  string
+	sourcename string
 }
 
 // New creates a new kubernetes executor.
@@ -44,8 +44,8 @@ func New(driver mesos.ExecutorDriver, kl *kubelet.Kubelet, ch chan<- interface{}
 		driver:     driver,
 		registered: false,
 		tasks:      make(map[string]*kuberTask),
-		pods:       make(map[string]*kubelet.Pod),
-		namespace:  ns,
+		pods:       make(map[string]*api.BoundPod),
+		sourcename: ns,
 	}
 }
 
@@ -91,36 +91,32 @@ func (k *KubernetesExecutor) LaunchTask(driver mesos.ExecutorDriver, taskInfo *m
 		// may be duplicated messages or duplicated task id.
 		return
 	}
-	// Get the container manifest from the taskInfo.
-	var manifest api.ContainerManifest
-	if err := yaml.Unmarshal(taskInfo.GetData(), &manifest); err != nil {
+	// Get the bound pod spec from the taskInfo.
+	var pod api.BoundPod
+	if err := yaml.Unmarshal(taskInfo.GetData(), &pod); err != nil {
 		log.Warningf("Failed to extract yaml data from the taskInfo.data %v\n", err)
 		k.sendStatusUpdate(taskInfo.GetTaskId(),
 			mesos.TaskState_TASK_FAILED, "Failed to extract yaml data")
 		return
 	}
 
-	// TODO(nnielsen): Verify this assumption. Manifest ID's has been marked
-	// to be deprecated.
-	podID := manifest.ID
-	uuid := manifest.UUID
+	podFullName := kubelet.GetPodFullName(&api.BoundPod{
+		ObjectMeta: api.ObjectMeta{
+			Name:        pod.Name,
+			Namespace:   pod.Namespace,
+			Annotations: map[string]string{kubelet.ConfigSourceAnnotationKey: k.sourcename},
+		},
+	})
 
 	// Add the task.
 	k.tasks[taskId] = &kuberTask{
-		mesosTaskInfo:     taskInfo,
-		containerManifest: &manifest,
+		mesosTaskInfo: taskInfo,
+		podName:       podFullName,
 	}
-
-	pod := kubelet.Pod{
-		Name:      podID,
-		Namespace: k.namespace,
-		Manifest:  manifest,
-	}
-	k.pods[podID] = &pod
+	k.pods[pod.Name] = &pod
 
 	getPidInfo := func(name string) (api.PodInfo, error) {
-		podFullName := kubelet.GetPodFullName(&kubelet.Pod{Name: name, Namespace: k.namespace})
-		return k.kl.GetPodInfo(podFullName, uuid)
+		return k.kl.GetPodInfo(name, "")
 	}
 
 	// TODO(nnielsen): Fail if container is already running.
@@ -147,7 +143,7 @@ func (k *KubernetesExecutor) LaunchTask(driver mesos.ExecutorDriver, taskInfo *m
 			// there is no existing event / push model for this.
 			time.Sleep(containerPollTime)
 
-			info, err := getPidInfo(podID)
+			info, err := getPidInfo(podFullName)
 			if err != nil {
 				continue
 			}
@@ -158,7 +154,7 @@ func (k *KubernetesExecutor) LaunchTask(driver mesos.ExecutorDriver, taskInfo *m
 			statusUpdate := &mesos.TaskStatus{
 				TaskId:  taskInfo.GetTaskId(),
 				State:   mesos.NewTaskState(mesos.TaskState_TASK_RUNNING),
-				Message: proto.String("Pod '" + podID + "' is running"),
+				Message: proto.String("Pod '" + podFullName + "' is running"),
 				Data:    data,
 			}
 
@@ -171,7 +167,7 @@ func (k *KubernetesExecutor) LaunchTask(driver mesos.ExecutorDriver, taskInfo *m
 			// What if the docker daemon is restarting and we can't connect, but it's
 			// going to bring the pods back online as soon as it restarts?
 			knownPod := func() bool {
-				_, err := getPidInfo(podID)
+				_, err := getPidInfo(podFullName)
 				return err == nil
 			}
 			go func() {
@@ -247,9 +243,7 @@ func (k *KubernetesExecutor) killPodForTask(tid, reason string) {
 	}
 	delete(k.tasks, tid)
 
-	// TODO(nnielsen): Verify this assumption. Manifest ID's has been marked
-	// to be deprecated.
-	pid := task.containerManifest.ID
+	pid := task.podName
 	if _, found := k.pods[pid]; !found {
 		log.Warningf("Cannot remove Unknown pod %v for task %v", pid, tid)
 	} else {
@@ -278,9 +272,7 @@ func (k *KubernetesExecutor) reportLostTask(tid, reason string) {
 	}
 	delete(k.tasks, tid)
 
-	// TODO(nnielsen): Verify this assumption. Manifest ID's has been marked
-	// to be deprecated.
-	pid := task.containerManifest.ID
+	pid := task.podName
 	if _, found := k.pods[pid]; !found {
 		log.Warningf("Cannot remove Unknown pod %v for lost task %v", pid, tid)
 	} else {

--- a/hack/dockerbuild/README.md
+++ b/hack/dockerbuild/README.md
@@ -52,11 +52,13 @@ Want a quick-and-dirty development environment to start hacking?
 
 Need to build the project, but from a forked git repo?
 
-    $ docker run --rm -v /tmp/target:/target -e GIT_REPO=https://github.com/whoami/kubernetes-mesos jdef/kubernetes-mesos:build-latest
+    $ docker run --rm -v /tmp/target:/target -e GIT_REPO=https://github.com/whoami/kubernetes-mesos \
+        jdef/kubernetes-mesos:build-latest
 
 To hack in your currently checked out repo mount the root of the github repo to `/snapshot`:
 
-    $ docker run -ti -v /tmp/target:/target -v /home/jdef/kubernetes-mesos:/snapshot jdef/kubernetes-mesos:build-latest bash
+    $ docker run -ti -v /tmp/target:/target -v /home/jdef/kubernetes-mesos:/snapshot \
+        jdef/kubernetes-mesos:build-latest bash
 
 ## Profiling
 

--- a/hack/patches/k8s---issue107.patch
+++ b/hack/patches/k8s---issue107.patch
@@ -1,0 +1,14 @@
+diff --git a/cmd/kube-proxy/proxy.go b/cmd/kube-proxy/proxy.go
+index 61fb4f8..e07a52c 100644
+--- a/cmd/kube-proxy/proxy.go
++++ b/cmd/kube-proxy/proxy.go
+@@ -119,6 +119,9 @@ func main() {
+ 	}
+ 	loadBalancer := proxy.NewLoadBalancerRR()
+ 	proxier := proxy.NewProxier(loadBalancer, net.IP(bindAddress), iptables.New(exec.New(), protocol))
++	if proxier == nil {
++		glog.Fatalf("failed to create proxier, aborting")
++	}
+ 	// Wire proxier to handle changes to services
+ 	serviceConfig.RegisterHandler(proxier)
+ 	// And wire loadBalancer to handle changes to endpoints to services

--- a/hack/patches/k8s---issue110.patch
+++ b/hack/patches/k8s---issue110.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/registry/pod/rest.go b/pkg/registry/pod/rest.go
+index c3c14b6..8138bae 100644
+--- a/pkg/registry/pod/rest.go
++++ b/pkg/registry/pod/rest.go
+@@ -234,7 +234,7 @@ func (rs *REST) fillPodInfo(pod *api.Pod) {
+ 		if ok {
+ 			if netContainerInfo.PodIP != "" {
+ 				pod.Status.PodIP = netContainerInfo.PodIP
+-			} else {
++			} else if netContainerInfo.State.Running != nil {
+ 				glog.Warningf("No network settings: %#v", netContainerInfo)
+ 			}
+ 		} else {

--- a/hack/patches/k8s---issue77.patch
+++ b/hack/patches/k8s---issue77.patch
@@ -1,8 +1,28 @@
 diff --git a/pkg/kubelet/dockertools/docker.go b/pkg/kubelet/dockertools/docker.go
-index 2f1bb12..46464ce 100644
+index f14cb61..a8e99ed 100644
 --- a/pkg/kubelet/dockertools/docker.go
 +++ b/pkg/kubelet/dockertools/docker.go
-@@ -208,6 +208,9 @@ func GetKubeletDockerContainers(client DockerInterface, allContainers bool) (Doc
+@@ -255,6 +255,9 @@ type DockerContainers map[DockerID]*docker.APIContainers
+ 
+ func (c DockerContainers) FindPodContainer(podFullName, uuid, containerName string) (*docker.APIContainers, bool, uint64) {
+ 	for _, dockerContainer := range c {
++		if len(dockerContainer.Names) == 0 {
++			continue
++		}
+ 		// TODO(proppy): build the docker container name and do a map lookup instead?
+ 		dockerManifestID, dockerUUID, dockerContainerName, hash := ParseDockerName(dockerContainer.Names[0])
+ 		if dockerManifestID == podFullName &&
+@@ -271,6 +274,9 @@ func (c DockerContainers) FindContainersByPodFullName(podFullName string) map[st
+ 	containers := make(map[string]*docker.APIContainers)
+ 
+ 	for _, dockerContainer := range c {
++		if len(dockerContainer.Names) == 0 {
++			continue
++		}
+ 		dockerManifestID, _, dockerContainerName, _ := ParseDockerName(dockerContainer.Names[0])
+ 		if dockerManifestID == podFullName {
+ 			containers[dockerContainerName] = dockerContainer
+@@ -289,6 +295,9 @@ func GetKubeletDockerContainers(client DockerInterface, allContainers bool) (Doc
  	}
  	for i := range containers {
  		container := &containers[i]
@@ -12,7 +32,7 @@ index 2f1bb12..46464ce 100644
  		// Skip containers that we didn't create to allow users to manually
  		// spin up their own containers if they want.
  		// TODO(dchen1107): Remove the old separator "--" by end of Oct
-@@ -230,6 +233,9 @@ func GetRecentDockerContainersWithNameAndUUID(client DockerInterface, podFullNam
+@@ -311,6 +320,9 @@ func GetRecentDockerContainersWithNameAndUUID(client DockerInterface, podFullNam
  		return nil, err
  	}
  	for _, dockerContainer := range containers {
@@ -22,7 +42,7 @@ index 2f1bb12..46464ce 100644
  		dockerPodName, dockerUUID, dockerContainerName, _ := ParseDockerName(dockerContainer.Names[0])
  		if dockerPodName != podFullName {
  			continue
-@@ -340,6 +346,9 @@ func GetDockerPodInfo(client DockerInterface, manifest api.ContainerManifest, po
+@@ -439,6 +451,9 @@ func GetDockerPodInfo(client DockerInterface, manifest api.PodSpec, podFullName,
  	}
  
  	for _, value := range containers {

--- a/hack/patches/k8s---issue77.patch
+++ b/hack/patches/k8s---issue77.patch
@@ -32,16 +32,6 @@ index f14cb61..a8e99ed 100644
  		// Skip containers that we didn't create to allow users to manually
  		// spin up their own containers if they want.
  		// TODO(dchen1107): Remove the old separator "--" by end of Oct
-@@ -311,6 +320,9 @@ func GetRecentDockerContainersWithNameAndUUID(client DockerInterface, podFullNam
- 		return nil, err
- 	}
- 	for _, dockerContainer := range containers {
-+		if len(dockerContainer.Names) == 0 {
-+			continue
-+		}
- 		dockerPodName, dockerUUID, dockerContainerName, _ := ParseDockerName(dockerContainer.Names[0])
- 		if dockerPodName != podFullName {
- 			continue
 @@ -439,6 +451,9 @@ func GetDockerPodInfo(client DockerInterface, manifest api.PodSpec, podFullName,
  	}
  

--- a/kubernetes-executor/main.go
+++ b/kubernetes-executor/main.go
@@ -14,11 +14,14 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/clientauth"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/health"
 	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/healthz"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	kconfig "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version/verflag"
 	"github.com/coreos/go-etcd/etcd"
@@ -29,14 +32,14 @@ import (
 )
 
 const (
-	POD_NS         string = "mesos" // k8s pod namespace
-	defaultRootDir        = "/var/lib/kubelet"
+	MESOS_CFG_SOURCE = "mesos" // @see ConfigSourceAnnotationKey
+	defaultRootDir   = "/var/lib/kubelet"
 )
 
 var (
 	syncFrequency           = flag.Duration("sync_frequency", 10*time.Second, "Max period between synchronizing running containers and config")
 	address                 = util.IP(net.ParseIP("0.0.0.0"))
-	port                    = flag.Uint("port", master.KubeletPort, "The port for the info server to serve on") // TODO(jdef): use kmmaster.KubeletExecutorPort
+	port                    = flag.Uint("port", ports.KubeletPort, "The port for the info server to serve on") // TODO(jdef): use kmmaster.KubeletExecutorPort
 	hostnameOverride        = flag.String("hostname_override", "", "If non-empty, will use this string as identification instead of the actual hostname.")
 	networkContainerImage   = flag.String("network_container_image", kubelet.NetworkContainerImage, "The image that network containers in each pod will use.")
 	dockerEndpoint          = flag.String("docker_endpoint", "", "If non-empty, use this for the docker endpoint to communicate with")
@@ -49,11 +52,14 @@ var (
 	enableDebuggingHandlers = flag.Bool("enable_debugging_handlers", true, "Enables server endpoints for log collection and local running of containers and commands. Default true.")
 	minimumGCAge            = flag.Duration("minimum_container_ttl_duration", 0, "Minimum age for a finished container before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'")
 	maxContainerCount       = flag.Int("maximum_dead_containers_per_container", 5, "Maximum number of old instances of a container to retain per container.  Each container takes up some disk space.  Default: 5.")
+	authPath                = flag.String("auth_path", "", "Path to .kubernetes_auth file, specifying how to authenticate to API server.")
+	apiServerList           util.StringList
 )
 
 func init() {
 	flag.Var(&etcdServerList, "etcd_servers", "List of etcd servers to watch (http://ip:port), comma separated")
 	flag.Var(&address, "address", "The IP address for the info and proxy servers to serve on. Default to 0.0.0.0.")
+	flag.Var(&apiServerList, "api_servers", "List of Kubernetes API servers to publish events to. (ip:port), comma separated.")
 }
 
 func getDockerEndpoint() string {
@@ -84,6 +90,27 @@ func getHostname() string {
 	return strings.TrimSpace(string(hostname))
 }
 
+func getApiserverClient() (*client.Client, error) {
+	authInfo, err := clientauth.LoadFromFile(*authPath)
+	if err != nil {
+		return nil, err
+	}
+	clientConfig, err := authInfo.MergeWithConfig(client.Config{})
+	if err != nil {
+		return nil, err
+	}
+	// TODO: adapt Kube client to support LB over several servers
+	if len(apiServerList) > 1 {
+		log.Infof("Mulitple api servers specified.  Picking first one")
+	}
+	clientConfig.Host = apiServerList[0]
+	if c, err := client.New(&clientConfig); err != nil {
+		return nil, err
+	} else {
+		return c, nil
+	}
+}
+
 func main() {
 
 	flag.Parse()
@@ -94,6 +121,22 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	etcd.SetLogger(util.NewLogger("etcd "))
+
+	// Make an API client if possible.
+	if len(apiServerList) < 1 {
+		log.Info("No api servers specified.")
+	} else {
+		if apiClient, err := getApiserverClient(); err != nil {
+			log.Errorf("Unable to make apiserver client: %v", err)
+		} else {
+			// Send events to APIserver if there is a client.
+			log.Infof("Sending events to APIserver.")
+			record.StartRecording(apiClient.Events(""), "kubelet")
+		}
+	}
+
+	// Log the events locally too.
+	record.StartLogging(log.Infof)
 
 	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: *allowPrivileged,
@@ -167,6 +210,9 @@ func main() {
 		*registryBurst,
 		*minimumGCAge,
 		*maxContainerCount)
+
+	kl.BirthCry()
+
 	go func() {
 		util.Forever(func() {
 			err := kl.GarbageCollectContainers()
@@ -198,7 +244,7 @@ func main() {
 	health.AddHealthChecker(&health.TCPHealthChecker{})
 
 	driver := new(mesos.MesosExecutorDriver)
-	kubeletExecutor := executor.New(driver, kl, cfg.Channel(POD_NS), POD_NS)
+	kubeletExecutor := executor.New(driver, kl, cfg.Channel(MESOS_CFG_SOURCE), MESOS_CFG_SOURCE)
 	driver.Executor = kubeletExecutor
 
 	log.V(2).Infof("Initialize executor driver...")
@@ -216,7 +262,7 @@ func main() {
 	log.Infof("Starting kubelet server...")
 	go util.Forever(func() {
 		// TODO(nnielsen): Don't hardwire port, but use port from resource offer.
-		log.Error(executor.ListenAndServeKubeletServer(kl, net.IP(address), *port, *enableDebuggingHandlers, POD_NS))
+		log.Error(executor.ListenAndServeKubeletServer(kl, net.IP(address), *port, *enableDebuggingHandlers, MESOS_CFG_SOURCE))
 	}, 0)
 
 	go runProxyService()

--- a/kubernetes-executor/plugins.go
+++ b/kubernetes-executor/plugins.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// HACK(jdef): cloned from https://github.com/GoogleCloudPlatform/kubernetes/blob/v0.5.4/cmd/kubelet/plugins.go
+package main
+
+// This file exists to force the desired plugin implementations to be linked.
+// This should probably be part of some configuration fed into the build for a
+// given binary target.
+import (
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/credentialprovider/gcp"
+)

--- a/kubernetes-mesos/main.go
+++ b/kubernetes-mesos/main.go
@@ -86,13 +86,13 @@ var (
 		Port:        10250,
 		EnableHttps: false,
 	}
-	mesosMaster  = flag.String("mesos_master", "localhost:5050", "Location of leading Mesos master. Default localhost:5050.")
-	executorPath = flag.String("executor_path", "", "Location of the kubernetes executor executable")
-	proxyPath    = flag.String("proxy_path", "", "Location of the kubernetes proxy executable")
-	mesosUser             = flag.String("mesos_user", "", "Mesos user for this framework, defaults to the username that owns the framework process.")
-	mesosRole             = flag.String("mesos_role", "", "Mesos role for this framework, defaults to none.")
-	mesosAuthPrincipal    = flag.String("mesos_authentication_principal", "", "Mesos authentication principal.")
-	mesosAuthSecretFile   = flag.String("mesos_authentication_secret_file", "", "Mesos authentication secret file.")
+	mesosMaster         = flag.String("mesos_master", "localhost:5050", "Location of leading Mesos master. Default localhost:5050.")
+	executorPath        = flag.String("executor_path", "", "Location of the kubernetes executor executable")
+	proxyPath           = flag.String("proxy_path", "", "Location of the kubernetes proxy executable")
+	mesosUser           = flag.String("mesos_user", "", "Mesos user for this framework, defaults to the username that owns the framework process.")
+	mesosRole           = flag.String("mesos_role", "", "Mesos role for this framework, defaults to none.")
+	mesosAuthPrincipal  = flag.String("mesos_authentication_principal", "", "Mesos authentication principal.")
+	mesosAuthSecretFile = flag.String("mesos_authentication_secret_file", "", "Mesos authentication secret file.")
 )
 
 const (

--- a/kubernetes-mesos/main.go
+++ b/kubernetes-mesos/main.go
@@ -157,9 +157,9 @@ func serveExecutorArtifact(path string) (*string, string) {
 func prepareExecutorInfo() *mesos.ExecutorInfo {
 	executorUris := []*mesos.CommandInfo_URI{}
 	uri, _ := serveExecutorArtifact(*proxyPath)
-	executorUris = append(executorUris, &mesos.CommandInfo_URI{Value: uri})
+	executorUris = append(executorUris, &mesos.CommandInfo_URI{Value: uri, Executable: proto.Bool(true)})
 	uri, executorCmd := serveExecutorArtifact(*executorPath)
-	executorUris = append(executorUris, &mesos.CommandInfo_URI{Value: uri})
+	executorUris = append(executorUris, &mesos.CommandInfo_URI{Value: uri, Executable: proto.Bool(true)})
 
 	//TODO(jdef): provide some way (env var?) for user's to customize executor config
 	//TODO(jdef): set -hostname_override and -address to 127.0.0.1 if `address` is 127.0.0.1

--- a/kubernetes-mesos/main.go
+++ b/kubernetes-mesos/main.go
@@ -164,7 +164,7 @@ func prepareExecutorInfo() *mesos.ExecutorInfo {
 	//TODO(jdef): provide some way (env var?) for user's to customize executor config
 	//TODO(jdef): set -hostname_override and -address to 127.0.0.1 if `address` is 127.0.0.1
 	//TODO(jdef): kubelet can publish events to the api server, we should probably tell it our IP address
-	executorCommand := fmt.Sprintf("./%s -v=2 -hostname_override=0.0.0.0", executorCmd)
+	executorCommand := fmt.Sprintf("./%s -v=2 -hostname_override=0.0.0.0 -allow_privileged=%t", executorCmd, *allowPrivileged)
 	if len(etcdServerList) > 0 {
 		etcdServerArguments := strings.Join(etcdServerList, ",")
 		executorCommand = fmt.Sprintf("%s -etcd_servers=%s", executorCommand, etcdServerArguments)

--- a/kubernetes-mesos/main.go
+++ b/kubernetes-mesos/main.go
@@ -178,11 +178,13 @@ func prepareExecutorInfo() *mesos.ExecutorInfo {
 	log.V(2).Info("Serving executor artifacts...")
 
 	// Create mesos scheduler driver.
+	// TODO(jdef): don't hardcode executor user here
 	return &mesos.ExecutorInfo{
 		ExecutorId: &mesos.ExecutorID{Value: proto.String("KubeleteExecutorID")},
 		Command: &mesos.CommandInfo{
 			Value: proto.String(executorCommand),
 			Uris:  executorUris,
+			User:  proto.String("root"), // must be able to use docker socket
 		},
 		Name:   proto.String("Kubelet Executor"),
 		Source: proto.String("kubernetes"),

--- a/kubernetes-mesos/main.go
+++ b/kubernetes-mesos/main.go
@@ -224,6 +224,11 @@ func main() {
 
 	n := net.IPNet(portalNet)
 
+	authenticator, err := apiserver.NewAuthenticatorFromTokenFile(*tokenAuthFile)
+	if err != nil {
+		log.Fatalf("Invalid Authentication Config: %v", err)
+	}
+
 	authorizer, err := apiserver.NewAuthorizerFromAuthorizationConfig(*authorizationMode, *authorizationPolicyFile)
 	if err != nil {
 		log.Fatalf("Invalid Authorization Config: %v", err)
@@ -252,10 +257,10 @@ func main() {
 		EnableUISupport:       true,
 		APIPrefix:             *apiPrefix,
 		CorsAllowedOriginList: corsAllowedOriginList,
-		TokenAuthFile:         *tokenAuthFile,
 		ReadOnlyPort:          *readOnlyPort,
 		ReadWritePort:         *port,
 		PublicAddress:         *publicAddressOverride,
+		Authenticator:         authenticator,
 		Authorizer:            authorizer,
 		PRFactory:             func() pod.Registry { return mesosPodScheduler },
 	}

--- a/kubernetes-mesos/main.go
+++ b/kubernetes-mesos/main.go
@@ -178,13 +178,11 @@ func prepareExecutorInfo() *mesos.ExecutorInfo {
 	log.V(2).Info("Serving executor artifacts...")
 
 	// Create mesos scheduler driver.
-	// TODO(jdef): don't hardcode executor user here
 	return &mesos.ExecutorInfo{
 		ExecutorId: &mesos.ExecutorID{Value: proto.String("KubeleteExecutorID")},
 		Command: &mesos.CommandInfo{
 			Value: proto.String(executorCommand),
 			Uris:  executorUris,
-			User:  proto.String("root"), // must be able to use docker socket
 		},
 		Name:   proto.String("Kubelet Executor"),
 		Source: proto.String("kubernetes"),

--- a/master/handlers.go
+++ b/master/handlers.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// HACK(jdef): cloned from https://github.com/GoogleCloudPlatform/kubernetes/blob/v0.5.4/pkg/master/handlers.go
+package master
+
+import (
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authenticator"
+
+	"github.com/emicklei/go-restful"
+)
+
+// handleWhoAmI returns the user-string which this request is authenticated as (if any).
+// Useful for debugging authentication.  Always returns HTTP status okay and a human
+// readable (not intended as API) description of authentication state of request.
+func handleWhoAmI(auth authenticator.Request) restful.RouteFunction {
+	return func(req *restful.Request, resp *restful.Response) {
+		// This is supposed to go away, so it's not worth the effort to convert to restful
+		w := resp.ResponseWriter
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		if auth == nil {
+			w.Write([]byte("NO AUTHENTICATION SUPPORT"))
+			return
+		}
+		userInfo, ok, err := auth.AuthenticateRequest(req.Request)
+		if err != nil {
+			w.Write([]byte("ERROR WHILE AUTHENTICATING"))
+			return
+		}
+		if !ok {
+			w.Write([]byte("NOT AUTHENTICATED"))
+			return
+		}
+		w.Write([]byte("AUTHENTICATED AS " + userInfo.GetName()))
+		return
+	}
+}

--- a/master/master.go
+++ b/master/master.go
@@ -19,6 +19,15 @@ package master
 // HACK: copied from upstream /pkg/master/master.go, then hacked for our purposes
 
 import (
+	"bytes"
+	_ "expvar"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	rt "runtime"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -26,6 +35,11 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta2"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authenticator"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authenticator/bearertoken"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authenticator/tokenfile"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authorizer"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/handlers"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider"
 	kmaster "github.com/GoogleCloudPlatform/kubernetes/pkg/master"
@@ -40,8 +54,13 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/ui"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	kmscheduler "github.com/mesosphere/kubernetes-mesos/scheduler"
+
+	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/swagger"
+	"github.com/golang/glog"
 )
 
 const (
@@ -52,20 +71,43 @@ type PodRegistryFactory func() pod.Registry
 
 // Config is a structure used to configure a Master.
 type Config struct {
-	Client             *client.Client
-	Cloud              cloudprovider.Interface
-	EtcdHelper         tools.EtcdHelper
-	HealthCheckMinions bool
-	MinionCacheTTL     time.Duration
-	EventTTL           time.Duration
-	MinionRegexp       string
-	PodInfoGetter      client.PodInfoGetter
-	NodeResources      api.NodeResources
-	PRFactory          PodRegistryFactory
+	Client                *client.Client
+	Cloud                 cloudprovider.Interface
+	EtcdHelper            tools.EtcdHelper
+	HealthCheckMinions    bool
+	MinionCacheTTL        time.Duration
+	EventTTL              time.Duration
+	MinionRegexp          string
+	KubeletClient         client.KubeletClient
+	PortalNet             *net.IPNet
+	EnableLogsSupport     bool
+	EnableUISupport       bool
+	APIPrefix             string
+	CorsAllowedOriginList util.StringList
+	TokenAuthFile         string
+	Authorizer            authorizer.Authorizer
+
+	// Number of masters running; all masters must be started with the
+	// same value for this field. (Numbers > 1 currently untested.)
+	MasterCount int
+
+	// The port on PublicAddress where a read-only server will be installed.
+	// Defaults to 7080 if not set.
+	ReadOnlyPort int
+	// The port on PublicAddress where a read-write server will be installed.
+	// Defaults to 443 if not set.
+	ReadWritePort int
+
+	// If empty, the first result from net.InterfaceAddrs will be used.
+	PublicAddress string
+
+	// HACK(jdef): k8s-mesos implements a custom pod registry, we reference it this way
+	PRFactory PodRegistryFactory
 }
 
 // Master contains state for a Kubernetes cluster master/api server.
 type Master struct {
+	// "Inputs", Copied from Config
 	podRegistry        pod.Registry
 	controllerRegistry controller.Registry
 	serviceRegistry    service.Registry
@@ -75,7 +117,29 @@ type Master struct {
 	eventRegistry      generic.Registry
 	storage            map[string]apiserver.RESTStorage
 	client             *client.Client
-	manifestFactory    pod.ManifestFactory
+
+	portalNet             *net.IPNet
+	mux                   apiserver.Mux
+	handlerContainer      *restful.Container
+	rootWebService        *restful.WebService
+	enableLogsSupport     bool
+	enableUISupport       bool
+	apiPrefix             string
+	corsAllowedOriginList util.StringList
+	tokenAuthFile         string
+	authorizer            authorizer.Authorizer
+	masterCount           int
+
+	readOnlyServer  string
+	readWriteServer string
+	masterServices  *util.Runner
+
+	// "Outputs"
+	Handler         http.Handler
+	InsecureHandler http.Handler
+
+	// HACK(jdef): need to share this reference between the binding registry and the pod registry
+	boundPodFactory pod.BoundPodFactory
 }
 
 // NewEtcdHelper returns an EtcdHelper for the provided arguments or an error if the version
@@ -88,76 +152,317 @@ func NewEtcdHelper(client tools.EtcdGetSet, version string) (helper tools.EtcdHe
 	if err != nil {
 		return helper, err
 	}
-	return tools.EtcdHelper{client, versionInterfaces.Codec, tools.RuntimeVersionAdapter{versionInterfaces.ResourceVersioner}}, nil
+	return tools.EtcdHelper{client, versionInterfaces.Codec, tools.RuntimeVersionAdapter{versionInterfaces.MetadataAccessor}}, nil
 }
 
-// New returns a new instance of Master connected to the given etcd server.
+// setDefaults fills in any fields not set that are required to have valid data.
+func setDefaults(c *Config) {
+	if c.PortalNet == nil {
+		defaultNet := "10.0.0.0/24"
+		glog.Warningf("Portal net unspecified. Defaulting to %v.", defaultNet)
+		_, portalNet, err := net.ParseCIDR(defaultNet)
+		if err != nil {
+			glog.Fatalf("Unable to parse CIDR: %v", err)
+		}
+		c.PortalNet = portalNet
+	}
+	if c.MasterCount == 0 {
+		// Clearly, there will be at least one master.
+		c.MasterCount = 1
+	}
+	if c.ReadOnlyPort == 0 {
+		c.ReadOnlyPort = 7080
+	}
+	if c.ReadWritePort == 0 {
+		c.ReadWritePort = 443
+	}
+	for c.PublicAddress == "" {
+		// Find and use the first non-loopback address.
+		// TODO(k8s): potentially it'd be useful to skip the docker interface if it
+		// somehow is first in the list.
+		addrs, err := net.InterfaceAddrs()
+		if err != nil {
+			glog.Fatalf("Unable to get network interfaces: error='%v'", err)
+		}
+		found := false
+		for i := range addrs {
+			ip, _, err := net.ParseCIDR(addrs[i].String())
+			if err != nil {
+				glog.Errorf("Error parsing '%v': %v", addrs[i], err)
+				continue
+			}
+			if ip.IsLoopback() {
+				glog.Infof("'%v' (%v) is a loopback address, ignoring.", ip, addrs[i])
+				continue
+			}
+			found = true
+			c.PublicAddress = ip.String()
+			glog.Infof("Will report %v as public IP address.", ip)
+			break
+		}
+		if !found {
+			glog.Errorf("Unable to find suitible network address in list: '%v'\n"+
+				"Will try again in 5 seconds. Set the public address directly to avoid this wait.", addrs)
+			time.Sleep(5 * time.Second)
+		}
+	}
+}
+
+// New returns a new instance of Master from the given config.
+// Certain config fields will be set to a default value if unset,
+// including:
+//   PortalNet
+//   MasterCount
+//   ReadOnlyPort
+//   ReadWritePort
+//   PublicAddress
+// Certain config fields must be specified, including:
+//   KubeletClient
+// Public fields:
+//   Handler -- The returned master has a field TopHandler which is an
+//   http.Handler which handles all the endpoints provided by the master,
+//   including the API, the UI, and miscelaneous debugging endpoints.  All
+//   these are subject to authorization and authentication.
+//   InsecureHandler -- an http.Handler which handles all the same
+//   endpoints as Handler, but no authorization and authentication is done.
+// Public methods:
+//   HandleWithAuth -- Allows caller to add an http.Handler for an endpoint
+//   that uses the same authentication and authorization (if any is configured)
+//   as the master's built-in endpoints.
+//   If the caller wants to add additional endpoints not using the master's
+//   auth, then the caller should create a handler for those endpoints, which delegates the
+//   any unhandled paths to "Handler".
 func New(c *Config) *Master {
+	setDefaults(c)
 	minionRegistry := makeMinionRegistry(c)
 	serviceRegistry := etcd.NewRegistry(c.EtcdHelper, nil)
-	manifestFactory := &pod.BasicManifestFactory{
+	boundPodFactory := &pod.BasicBoundPodFactory{
 		ServiceRegistry: serviceRegistry,
 	}
-
-	m := &Master{
-		podRegistry:        c.PRFactory(),
-		controllerRegistry: etcd.NewRegistry(c.EtcdHelper, nil),
-		serviceRegistry:    serviceRegistry,
-		endpointRegistry:   etcd.NewRegistry(c.EtcdHelper, nil),
-		bindingRegistry:    etcd.NewRegistry(c.EtcdHelper, manifestFactory),
-		eventRegistry:      event.NewEtcdRegistry(c.EtcdHelper, uint64(c.EventTTL.Seconds())),
-		minionRegistry:     minionRegistry,
-		client:             c.Client,
-		manifestFactory:    manifestFactory,
+	if c.KubeletClient == nil {
+		glog.Fatalf("master.New() called with config.KubeletClient == nil")
 	}
-	m.init(c.Cloud, c.PodInfoGetter)
+	mx := http.NewServeMux()
+	m := &Master{
+		podRegistry:           c.PRFactory(),
+		controllerRegistry:    etcd.NewRegistry(c.EtcdHelper, nil),
+		serviceRegistry:       serviceRegistry,
+		endpointRegistry:      etcd.NewRegistry(c.EtcdHelper, nil),
+		bindingRegistry:       etcd.NewRegistry(c.EtcdHelper, boundPodFactory),
+		eventRegistry:         event.NewEtcdRegistry(c.EtcdHelper, uint64(c.EventTTL.Seconds())),
+		minionRegistry:        minionRegistry,
+		client:                c.Client,
+		portalNet:             c.PortalNet,
+		mux:                   mx,
+		handlerContainer:      NewHandlerContainer(mx),
+		rootWebService:        new(restful.WebService),
+		enableLogsSupport:     c.EnableLogsSupport,
+		enableUISupport:       c.EnableUISupport,
+		apiPrefix:             c.APIPrefix,
+		corsAllowedOriginList: c.CorsAllowedOriginList,
+		tokenAuthFile:         c.TokenAuthFile,
+		authorizer:            c.Authorizer,
+
+		masterCount:     c.MasterCount,
+		readOnlyServer:  net.JoinHostPort(c.PublicAddress, strconv.Itoa(int(c.ReadOnlyPort))),
+		readWriteServer: net.JoinHostPort(c.PublicAddress, strconv.Itoa(int(c.ReadWritePort))),
+		boundPodFactory: boundPodFactory,
+	}
+	m.masterServices = util.NewRunner(m.serviceWriterLoop, m.roServiceWriterLoop)
+	m.init(c)
 	return m
+}
+
+// HandleWithAuth adds an http.Handler for pattern to an http.ServeMux
+// Applies the same authentication and authorization (if any is configured)
+// to the request is used for the master's built-in endpoints.
+func (m *Master) HandleWithAuth(pattern string, handler http.Handler) {
+	// TODO: Add a way for plugged-in endpoints to translate their
+	// URLs into attributes that an Authorizer can understand, and have
+	// sensible policy defaults for plugged-in endpoints.  This will be different
+	// for generic endpoints versus REST object endpoints.
+	// TODO: convert to go-restful
+	m.mux.Handle(pattern, handler)
+}
+
+// HandleFuncWithAuth adds an http.Handler for pattern to an http.ServeMux
+// Applies the same authentication and authorization (if any is configured)
+// to the request is used for the master's built-in endpoints.
+func (m *Master) HandleFuncWithAuth(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	// TODO: convert to go-restful
+	m.mux.HandleFunc(pattern, handler)
+}
+
+func NewHandlerContainer(mux *http.ServeMux) *restful.Container {
+	container := restful.NewContainer()
+	container.ServeMux = mux
+	container.RecoverHandler(logStackOnRecover)
+	return container
+}
+
+//TODO: Unify with RecoverPanics?
+func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) {
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("recover from panic situation: - %v\r\n", panicReason))
+	for i := 2; ; i += 1 {
+		_, file, line, ok := rt.Caller(i)
+		if !ok {
+			break
+		}
+		buffer.WriteString(fmt.Sprintf("    %s:%d\r\n", file, line))
+	}
+	glog.Errorln(buffer.String())
 }
 
 func makeMinionRegistry(c *Config) minion.Registry {
 	minionRegistry := kmscheduler.NewCloudRegistry(c.Cloud)
-
 	/* TODO(jdef): kubelet-executors may not be running on all slaves, need to be sure which slaves
 	are running such before we start doing health checks, etc...
 
 	if c.HealthCheckMinions {
-		minionRegistry = minion.NewHealthyRegistry(minionRegistry, &http.Client{})
-	}
-	if c.MinionCacheTTL > 0 {
-		cachingMinionRegistry, err := minion.NewCachingRegistry(minionRegistry, c.MinionCacheTTL)
-		if err != nil {
-			glog.Errorf("Failed to initialize caching layer, ignoring cache.")
-		} else {
-			minionRegistry = cachingMinionRegistry
-		}
+		minionRegistry = minion.NewHealthyRegistry(minionRegistry, c.KubeletClient)
 	}
 	*/
 	return minionRegistry
 }
 
-func (m *Master) init(cloud cloudprovider.Interface, podInfoGetter client.PodInfoGetter) {
-	podCache := kmaster.NewPodCache(podInfoGetter, m.podRegistry)
+func (m *Master) init(c *Config) {
+	podCache := kmaster.NewPodCache(c.KubeletClient, m.podRegistry)
 	go util.Forever(func() { podCache.UpdateAllContainers() }, cachePeriod)
 
+	var userContexts = handlers.NewUserRequestContext()
+	var authenticator authenticator.Request
+	if len(c.TokenAuthFile) != 0 {
+		tokenAuthenticator, err := tokenfile.New(c.TokenAuthFile)
+		if err != nil {
+			glog.Fatalf("Unable to load the token authentication file '%s': %v", c.TokenAuthFile, err)
+		}
+		authenticator = bearertoken.New(tokenAuthenticator)
+	}
+
+	// TODO(k8s): Factor out the core API registration
 	m.storage = map[string]apiserver.RESTStorage{
 		"pods": pod.NewREST(&pod.RESTConfig{
-			CloudProvider: cloud,
+			CloudProvider: c.Cloud,
 			PodCache:      podCache,
-			PodInfoGetter: podInfoGetter,
+			PodInfoGetter: c.KubeletClient,
 			Registry:      m.podRegistry,
-			Minions:       m.client,
+			Minions:       m.client.Minions(),
 		}),
 		"replicationControllers": controller.NewREST(m.controllerRegistry, m.podRegistry),
-		"services":               service.NewREST(m.serviceRegistry, cloud, m.minionRegistry),
+		"services":               service.NewREST(m.serviceRegistry, c.Cloud, m.minionRegistry, m.portalNet),
 		"endpoints":              endpoint.NewREST(m.endpointRegistry),
 		"minions":                minion.NewREST(m.minionRegistry),
 		"events":                 event.NewREST(m.eventRegistry),
-		"bindings":               binding.NewREST(m.bindingRegistry),
+
+		// TODO(k8s): should appear only in scheduler API group.
+		"bindings": binding.NewREST(m.bindingRegistry),
 	}
+
+	apiserver.NewAPIGroupVersion(m.API_v1beta1()).InstallREST(m.handlerContainer, c.APIPrefix, "v1beta1")
+	apiserver.NewAPIGroupVersion(m.API_v1beta2()).InstallREST(m.handlerContainer, c.APIPrefix, "v1beta2")
+
+	// TODO: InstallREST should register each version automatically
+	versionHandler := apiserver.APIVersionHandler("v1beta1", "v1beta2")
+	m.rootWebService.Route(m.rootWebService.GET(c.APIPrefix).To(versionHandler))
+
+	apiserver.InstallSupport(m.handlerContainer, m.rootWebService)
+
+	// TODO: use go-restful
+	serversToValidate := m.getServersToValidate(c)
+	apiserver.InstallValidator(m.mux, serversToValidate)
+	if c.EnableLogsSupport {
+		apiserver.InstallLogsSupport(m.mux)
+	}
+	if c.EnableUISupport {
+		ui.InstallSupport(m.mux)
+	}
+
+	// TODO: install runtime/pprof handler
+	// See github.com/emicklei/go-restful/blob/master/examples/restful-cpuprofiler-service.go
+
+	handler := http.Handler(m.mux.(*http.ServeMux))
+
+	// TODO: handle CORS and auth using go-restful
+	// See github.com/emicklei/go-restful/blob/master/examples/restful-CORS-filter.go, and
+	// github.com/emicklei/go-restful/blob/master/examples/restful-basic-authentication.go
+
+	if len(c.CorsAllowedOriginList) > 0 {
+		allowedOriginRegexps, err := util.CompileRegexps(c.CorsAllowedOriginList)
+		if err != nil {
+			glog.Fatalf("Invalid CORS allowed origin, --cors_allowed_origins flag was set to %v - %v", strings.Join(c.CorsAllowedOriginList, ","), err)
+		}
+		handler = apiserver.CORS(handler, allowedOriginRegexps, nil, nil, "true")
+	}
+
+	m.InsecureHandler = handler
+
+	attributeGetter := apiserver.NewRequestAttributeGetter(userContexts)
+	handler = apiserver.WithAuthorizationCheck(handler, attributeGetter, m.authorizer)
+
+	// Install Authenticator
+	if authenticator != nil {
+		handler = handlers.NewRequestAuthenticator(userContexts, authenticator, handlers.Unauthorized, handler)
+	}
+	// TODO: Remove temporary _whoami handler
+	m.rootWebService.Route(m.rootWebService.GET("/_whoami").To(handleWhoAmI(authenticator)))
+
+	// Install root web services
+	m.handlerContainer.Add(m.rootWebService)
+
+	// TODO: Make this optional?
+	// Enable swagger UI and discovery API
+	swaggerConfig := swagger.Config{
+		WebServices: m.handlerContainer.RegisteredWebServices(),
+		// TODO: Parameterize the path?
+		ApiPath: "/swaggerapi/",
+		// TODO: Distribute UI javascript and enable the UI
+		//SwaggerPath: "/swaggerui/",
+		//SwaggerFilePath: "/srv/apiserver/swagger/dist"
+	}
+	swagger.RegisterSwaggerService(swaggerConfig, m.handlerContainer)
+
+	m.Handler = handler
+
+	// TODO: Attempt clean shutdown?
+	m.masterServices.Start()
 }
 
-func (m *Master) GetManifestFactory() pod.ManifestFactory {
-	return m.manifestFactory
+func (m *Master) getServersToValidate(c *Config) map[string]apiserver.Server {
+	serversToValidate := map[string]apiserver.Server{
+		"controller-manager": {Addr: "127.0.0.1", Port: 10252, Path: "/healthz"},
+		"scheduler":          {Addr: "127.0.0.1", Port: 10251, Path: "/healthz"},
+	}
+	for ix, machine := range c.EtcdHelper.Client.GetCluster() {
+		etcdUrl, err := url.Parse(machine)
+		if err != nil {
+			glog.Errorf("Failed to parse etcd url for validation: %v", err)
+			continue
+		}
+		var port int
+		var addr string
+		if strings.Contains(etcdUrl.Host, ":") {
+			var portString string
+			addr, portString, err = net.SplitHostPort(etcdUrl.Host)
+			if err != nil {
+				glog.Errorf("Failed to split host/port: %s (%v)", etcdUrl.Host, err)
+				continue
+			}
+			port, _ = strconv.Atoi(portString)
+		} else {
+			addr = etcdUrl.Host
+			port = 4001
+		}
+		serversToValidate[fmt.Sprintf("etcd-%d", ix)] = apiserver.Server{Addr: addr, Port: port, Path: "/v2/keys/"}
+	}
+	nodes, err := m.minionRegistry.ListMinions(api.NewDefaultContext())
+	if err != nil {
+		glog.Errorf("Failed to list minions: %v", err)
+	}
+	for ix, node := range nodes.Items {
+		serversToValidate[fmt.Sprintf("node-%d", ix)] = apiserver.Server{Addr: node.HostIP, Port: 10250, Path: "/healthz"}
+	}
+	return serversToValidate
 }
 
 // API_v1beta1 returns the resources and codec for API version v1beta1.
@@ -176,4 +481,9 @@ func (m *Master) API_v1beta2() (map[string]apiserver.RESTStorage, runtime.Codec,
 		storage[k] = v
 	}
 	return storage, v1beta2.Codec, "/api/v1beta2", latest.SelfLinker
+}
+
+// HACK(jdef): factory method that our custom pod registry impl needs
+func (m *Master) GetBoundPodFactory() pod.BoundPodFactory {
+	return m.boundPodFactory
 }

--- a/master/publish.go
+++ b/master/publish.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// HACK(jdef): cloned from https://github.com/GoogleCloudPlatform/kubernetes/blob/v0.5.4/pkg/master/publish.go
+package master
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	"github.com/golang/glog"
+)
+
+func (m *Master) serviceWriterLoop(stop chan struct{}) {
+	for {
+		// Update service & endpoint records.
+		// TODO: when it becomes possible to change this stuff,
+		// stop polling and start watching.
+		// TODO: add endpoints of all replicas, not just the elected master.
+		if m.readWriteServer != "" {
+			if err := m.createMasterServiceIfNeeded("kubernetes", 443); err != nil {
+				glog.Errorf("Can't create rw service: %v", err)
+			}
+			if err := m.ensureEndpointsContain("kubernetes", m.readWriteServer); err != nil {
+				glog.Errorf("Can't create rw endpoints: %v", err)
+			}
+		}
+
+		select {
+		case <-stop:
+			return
+		case <-time.After(10 * time.Second):
+		}
+	}
+}
+
+func (m *Master) roServiceWriterLoop(stop chan struct{}) {
+	for {
+		// Update service & endpoint records.
+		// TODO: when it becomes possible to change this stuff,
+		// stop polling and start watching.
+		if m.readOnlyServer != "" {
+			if err := m.createMasterServiceIfNeeded("kubernetes-ro", 80); err != nil {
+				glog.Errorf("Can't create ro service: %v", err)
+			}
+			if err := m.ensureEndpointsContain("kubernetes-ro", m.readOnlyServer); err != nil {
+				glog.Errorf("Can't create ro endpoints: %v", err)
+			}
+		}
+
+		select {
+		case <-stop:
+			return
+		case <-time.After(10 * time.Second):
+		}
+	}
+}
+
+// createMasterServiceIfNeeded will create the specified service if it
+// doesn't already exist.
+func (m *Master) createMasterServiceIfNeeded(serviceName string, port int) error {
+	ctx := api.NewDefaultContext()
+	if _, err := m.serviceRegistry.GetService(ctx, serviceName); err == nil {
+		// The service already exists.
+		return nil
+	}
+	svc := &api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name:      serviceName,
+			Namespace: "default",
+		},
+		Spec: api.ServiceSpec{
+			Port: port,
+			// We're going to add the endpoints by hand, so this selector is mainly to
+			// prevent identification of other pods. This selector will be useful when
+			// we start hosting apiserver in a pod.
+			Selector: map[string]string{"provider": "kubernetes", "component": "apiserver"},
+		},
+	}
+	// Kids, don't do this at home: this is a hack. There's no good way to call the business
+	// logic which lives in the REST object from here.
+	c, err := m.storage["services"].Create(ctx, svc)
+	if err != nil {
+		return err
+	}
+	resp := <-c
+	if _, ok := resp.Object.(*api.Service); ok {
+		// If all worked, we get back an *api.Service object.
+		return nil
+	}
+	return fmt.Errorf("Unexpected response: %#v", resp)
+}
+
+// ensureEndpointsContain sets the endpoints for the given service. Also removes
+// excess endpoints (as determined by m.masterCount). Extra endpoints could appear
+// in the list if, for example, the master starts running on a different machine,
+// changing IP addresses.
+func (m *Master) ensureEndpointsContain(serviceName string, endpoint string) error {
+	ctx := api.NewDefaultContext()
+	e, err := m.endpointRegistry.GetEndpoints(ctx, serviceName)
+	if err != nil {
+		e = &api.Endpoints{}
+		// Fill in ID if it didn't exist already
+		e.ObjectMeta.Name = serviceName
+		e.ObjectMeta.Namespace = "default"
+	}
+	found := false
+	for i := range e.Endpoints {
+		if e.Endpoints[i] == endpoint {
+			found = true
+			break
+		}
+	}
+	if !found {
+		e.Endpoints = append(e.Endpoints, endpoint)
+	}
+	if len(e.Endpoints) > m.masterCount {
+		// We append to the end and remove from the beginning, so this should
+		// converge rapidly with all masters performing this operation.
+		e.Endpoints = e.Endpoints[len(e.Endpoints)-m.masterCount:]
+	} else if found {
+		// We didn't make any changes, no need to actually call update.
+		return nil
+	}
+	return m.endpointRegistry.UpdateEndpoints(ctx, e)
+}

--- a/scheduler/cloud.go
+++ b/scheduler/cloud.go
@@ -33,6 +33,13 @@ func (c *MesosCloud) Zones() (cloud.Zones, bool) {
 	return nil, false
 }
 
+// implementation of cloud.Interface; Mesos does not provide support for multiple clusters
+func (c *MesosCloud) Clusters() (cloud.Clusters, bool) {
+	//TODO(jdef): we could probably implement this and always return a
+	//single cluster- this one.
+	return nil, false
+}
+
 // implementation of cloud.Instances.
 // IPAddress returns an IP address of the specified instance.
 func (c *MesosCloud) IPAddress(name string) (net.IP, error) {

--- a/scheduler/cloud_registry.go
+++ b/scheduler/cloud_registry.go
@@ -22,6 +22,10 @@ func (r *CloudRegistry) CreateMinion(api.Context, *api.Minion) error {
 	return fmt.Errorf("unsupported")
 }
 
+func (r *CloudRegistry) UpdateMinion(api.Context, *api.Minion) error {
+	return fmt.Errorf("unsupported")
+}
+
 func (r *CloudRegistry) GetMinion(ctx api.Context, minionId string) (*api.Minion, error) {
 	instances, ok := r.cloud.Instances()
 	if !ok {
@@ -53,10 +57,11 @@ func (r *CloudRegistry) ListMinions(ctx api.Context) (*api.MinionList, error) {
 	for _, m := range hostnames {
 		minions = append(minions, *(toApiMinion(ctx, m)))
 	}
-	ns, _ := api.NamespaceFrom(ctx)
 	return &api.MinionList{
-		TypeMeta: api.TypeMeta{Kind: "minionList", Namespace: ns},
-		Items:    minions,
+		TypeMeta: api.TypeMeta{
+			Kind: "minionList",
+		},
+		Items: minions,
 	}, nil
 }
 
@@ -64,8 +69,10 @@ func toApiMinion(ctx api.Context, hostname string) *api.Minion {
 	ns, _ := api.NamespaceFrom(ctx)
 	return &api.Minion{
 		TypeMeta: api.TypeMeta{
-			ID:        hostname,
-			Kind:      "minion",
+			Kind: "minion",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name:      hostname,
 			Namespace: ns,
 		},
 		HostIP: hostname,

--- a/scheduler/cloud_registry.go
+++ b/scheduler/cloud_registry.go
@@ -75,6 +75,8 @@ func toApiMinion(ctx api.Context, hostname string) *api.Minion {
 			Name:      hostname,
 			Namespace: ns,
 		},
-		HostIP: hostname,
+		Status: api.NodeStatus{
+			HostIP: hostname,
+		},
 	}
 }

--- a/scheduler/offers.go
+++ b/scheduler/offers.go
@@ -222,7 +222,7 @@ func (s *offerStorage) invalidateOne(offerId string) {
 // Walker or when the end of the offer list is reached. Expired offers are
 // never passed to a Walker.
 func (s *offerStorage) Walk(w Walker) error {
-	for offerId := range s.offers.Contains() {
+	for offerId := range s.offers.ContainedIDs() {
 		offer, ok := s.Get(offerId)
 		if !ok {
 			// offer disappeared...
@@ -324,7 +324,7 @@ func (s *offerStorage) notifyListeners() {
 		log.Warningf("unexpected listener object %v", obj)
 	}
 	// notify if we find an acceptable offer
-	for id := range s.offers.Contains() {
+	for id := range s.offers.ContainedIDs() {
 		var offer PerishableOffer
 		if offer, ok = s.Get(id); !ok || offer.HasExpired() {
 			continue

--- a/scheduler/pod_task.go
+++ b/scheduler/pod_task.go
@@ -71,7 +71,7 @@ func (t *PodTask) FillTaskInfo(offer PerishableOffer) error {
 		return fmt.Errorf("Offer assignment must be idempotent with task %v: %v", t, offer)
 	}
 	t.Offer = offer
-	log.V(3).Infof("Recording offer(s) %v against pod %v", details.Id, t.Pod.ID)
+	log.V(3).Infof("Recording offer(s) %v against pod %v", details.Id, t.Pod.UID)
 
 	t.TaskInfo.TaskId = &mesos.TaskID{Value: proto.String(t.ID)}
 	t.TaskInfo.SlaveId = details.GetSlaveId()
@@ -92,7 +92,7 @@ func (t *PodTask) FillTaskInfo(offer PerishableOffer) error {
 // Clear offer-related details from the task, should be called if/when an offer
 // has already been assigned to a task but for some reason is no longer valid.
 func (t *PodTask) ClearTaskInfo() {
-	log.V(3).Infof("Clearing offer(s) from pod %v", t.Pod.ID)
+	log.V(3).Infof("Clearing offer(s) from pod %v", t.Pod.UID)
 	t.Offer = nil
 	t.TaskInfo.TaskId = nil
 	t.TaskInfo.SlaveId = nil
@@ -154,7 +154,7 @@ func (t *PodTask) AcceptOffer(offer *mesos.Offer) bool {
 
 	unsatisfiedPorts := len(requiredPorts)
 	if unsatisfiedPorts > 0 {
-		log.V(2).Infof("Could not schedule pod %s: %d ports could not be allocated", t.Pod.ID, unsatisfiedPorts)
+		log.V(2).Infof("Could not schedule pod %s: %d ports could not be allocated", t.Pod.UID, unsatisfiedPorts)
 		return false
 	}
 
@@ -169,7 +169,7 @@ func (t *PodTask) AcceptOffer(offer *mesos.Offer) bool {
 func newPodTask(pod *api.Pod, executor *mesos.ExecutorInfo) (*PodTask, error) {
 	taskId := uuid.NewUUID().String()
 	task := &PodTask{
-		ID:       taskId, // pod.JSONBase.ID,
+		ID:       taskId,
 		Pod:      pod,
 		TaskInfo: new(mesos.TaskInfo),
 		Launched: false,

--- a/scheduler/pod_task.go
+++ b/scheduler/pod_task.go
@@ -8,7 +8,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	log "github.com/golang/glog"
 	"github.com/mesos/mesos-go/mesos"
-	"gopkg.in/v1/yaml"
 )
 
 const (
@@ -83,10 +82,6 @@ func (t *PodTask) FillTaskInfo(offer PerishableOffer) error {
 	if ports := rangeResource("ports", t.Ports()); ports != nil {
 		t.TaskInfo.Resources = append(t.TaskInfo.Resources, ports)
 	}
-	var err error
-	if t.TaskInfo.Data, err = yaml.Marshal(&t.Pod.DesiredState.Manifest); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -103,7 +98,7 @@ func (t *PodTask) ClearTaskInfo() {
 
 func (t *PodTask) Ports() []uint64 {
 	ports := make([]uint64, 0)
-	for _, container := range t.Pod.DesiredState.Manifest.Containers {
+	for _, container := range t.Pod.Spec.Containers {
 		// strip all port==0 from this array; k8s already knows what to do with zero-
 		// ports (it does not create 'port bindings' on the minion-host); we need to
 		// remove the wildcards from this array since they don't consume host resources

--- a/scheduler/pod_task.go
+++ b/scheduler/pod_task.go
@@ -23,6 +23,7 @@ type PodTask struct {
 	TaskInfo *mesos.TaskInfo
 	Launched bool
 	Offer    PerishableOffer
+	podKey   string
 }
 
 func rangeResource(name string, ports []uint64) *mesos.Resource {
@@ -71,7 +72,7 @@ func (t *PodTask) FillTaskInfo(offer PerishableOffer) error {
 		return fmt.Errorf("Offer assignment must be idempotent with task %v: %v", t, offer)
 	}
 	t.Offer = offer
-	log.V(3).Infof("Recording offer(s) %v against pod %v", details.Id, t.Pod.UID)
+	log.V(3).Infof("Recording offer(s) %v against pod %v", details.Id, t.Pod.Name)
 
 	t.TaskInfo.TaskId = &mesos.TaskID{Value: proto.String(t.ID)}
 	t.TaskInfo.SlaveId = details.GetSlaveId()
@@ -92,7 +93,7 @@ func (t *PodTask) FillTaskInfo(offer PerishableOffer) error {
 // Clear offer-related details from the task, should be called if/when an offer
 // has already been assigned to a task but for some reason is no longer valid.
 func (t *PodTask) ClearTaskInfo() {
-	log.V(3).Infof("Clearing offer(s) from pod %v", t.Pod.UID)
+	log.V(3).Infof("Clearing offer(s) from pod %v", t.Pod.Name)
 	t.Offer = nil
 	t.TaskInfo.TaskId = nil
 	t.TaskInfo.SlaveId = nil
@@ -154,7 +155,7 @@ func (t *PodTask) AcceptOffer(offer *mesos.Offer) bool {
 
 	unsatisfiedPorts := len(requiredPorts)
 	if unsatisfiedPorts > 0 {
-		log.V(2).Infof("Could not schedule pod %s: %d ports could not be allocated", t.Pod.UID, unsatisfiedPorts)
+		log.V(2).Infof("Could not schedule pod %s: %d ports could not be allocated", t.Pod.Name, unsatisfiedPorts)
 		return false
 	}
 
@@ -166,15 +167,63 @@ func (t *PodTask) AcceptOffer(offer *mesos.Offer) bool {
 	return true
 }
 
-func newPodTask(pod *api.Pod, executor *mesos.ExecutorInfo) (*PodTask, error) {
+func newPodTask(ctx api.Context, pod *api.Pod, executor *mesos.ExecutorInfo) (*PodTask, error) {
+	key, err := makePodKey(ctx, pod.Name)
+	if err != nil {
+		return nil, err
+	}
 	taskId := uuid.NewUUID().String()
 	task := &PodTask{
 		ID:       taskId,
 		Pod:      pod,
 		TaskInfo: new(mesos.TaskInfo),
 		Launched: false,
+		podKey:   key,
 	}
 	task.TaskInfo.Name = proto.String("PodTask")
 	task.TaskInfo.Executor = executor
 	return task, nil
+}
+
+/**
+HACK(jdef): we're not using etcd but k8s has implemented namespace support and
+we're going to try to honor that by namespacing pod keys. Hence, the following
+funcs that were stolen from:
+    https://github.com/GoogleCloudPlatform/kubernetes/blob/release-0.5/pkg/registry/etcd/etcd.go
+**/
+
+const PodPath = "/pods"
+
+// makeListKey constructs etcd paths to resource directories enforcing namespace rules
+func makeListKey(ctx api.Context, prefix string) string {
+	key := prefix
+	ns, ok := api.NamespaceFrom(ctx)
+	if ok && len(ns) > 0 {
+		key = key + "/" + ns
+	}
+	return key
+}
+
+// makeItemKey constructs etcd paths to a resource relative to prefix enforcing namespace rules.  If no namespace is on context, it errors.
+func makeItemKey(ctx api.Context, prefix string, id string) (string, error) {
+	key := makeListKey(ctx, prefix)
+	ns, ok := api.NamespaceFrom(ctx)
+	if !ok || len(ns) == 0 {
+		return "", fmt.Errorf("Invalid request.  Namespace parameter required.")
+	}
+	if len(id) == 0 {
+		return "", fmt.Errorf("Invalid request.  Id parameter required.")
+	}
+	key = key + "/" + id
+	return key, nil
+}
+
+// makePodListKey constructs etcd paths to pod directories enforcing namespace rules.
+func makePodListKey(ctx api.Context) string {
+	return makeListKey(ctx, PodPath)
+}
+
+// makePodKey constructs etcd paths to pod items enforcing namespace rules.
+func makePodKey(ctx api.Context, id string) (string, error) {
+	return makeItemKey(ctx, PodPath, id)
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -486,9 +486,11 @@ func (k *KubernetesScheduler) yield() *api.Pod {
 	// HACK(jdef): refresh the pod data via the client, updates things like selflink that
 	// the upstream scheduling controller expects to have. Will not need this once we divorce
 	// scheduling from the apiserver (soon I hope)
-	pod, err := k.client.Pods(pod.Namespace).Get(pod.Name)
+	updatedPod, err := k.client.Pods(pod.Namespace).Get(pod.Name)
 	if err != nil {
 		log.Warningf("Failed to refresh pod %v, attempting to continue: %v", pod.Name, err)
+	} else {
+		pod = updatedPod
 	}
 
 	log.V(2).Infof("About to try and schedule pod %v\n", pod.Name)


### PR DESCRIPTION
This is a WIP -- use this branch at your own risk.

TODOs
- [x] single pod
- [x] replicated pod, pod failover
- [x] service backed by replicated pod
- [x] working guestbook pods, controllers, and services
- [x] guestbook UI accessible to Internet (see comments below)
- [x] update usage, example docs
- [x] update [GCE/guestbook tutorial](https://mesosphere.com/docs/tutorials/kubernetes-mesos-gcp/) (new master params, firewall steps, etc.)
- [x] lots of testing
- [ ] **post-merge:** rebuild jdef/redis, jdef/php-redis images
- [ ] **post-merge:** request merge of GCE tutorial PR (https://github.com/mesosphere/website/pull/416)