### PR TITLE
k8sm/expose label to indicate that hostPort==0 should be exposed on an available port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ WITH_MESOS_CGO_FLAGS :=  \
 	  CGO_CXXFLAGS="$(CGO_CXXFLAGS)" \
 	  CGO_LDFLAGS="$(CGO_LDFLAGS)"
 
+WITH_MESOS_LD_LIBRARY_PATH := LD_LIBRARY_PATH=$(WITH_MESOS_DIR)/lib
+
 endif
 
 export SHELL
@@ -84,7 +86,7 @@ format: require-gopath
 	go fmt $(FRAMEWORK_CMD) $(FRAMEWORK_LIB)
 
 test: require-gopath
-	go test $(FRAMEWORK_LIB)
+	env $(WITH_MESOS_CGO_FLAGS) $(WITH_MESOS_LD_LIBRARY_PATH) go test $(FRAMEWORK_LIB)
 
 install: all
 	mkdir -p $(DESTDIR)

--- a/scheduler/pod_task.go
+++ b/scheduler/pod_task.go
@@ -118,6 +118,11 @@ func (t *PodTask) Ports() []uint64 {
 }
 
 func (t *PodTask) AcceptOffer(offer *mesos.Offer) bool {
+
+	if offer == nil {
+		return false
+	}
+
 	var cpus float64 = 0
 	var mem float64 = 0
 
@@ -167,6 +172,12 @@ func (t *PodTask) AcceptOffer(offer *mesos.Offer) bool {
 }
 
 func newPodTask(pod *api.Pod, executor *mesos.ExecutorInfo) (*PodTask, error) {
+	if pod == nil {
+		return nil, fmt.Errorf("Illegal argument: pod was nil")
+	}
+	if executor == nil {
+		return nil, fmt.Errorf("Illegal argument: executor was nil")
+	}
 	taskId := uuid.NewUUID().String()
 	task := &PodTask{
 		ID:       taskId, // pod.JSONBase.ID,

--- a/scheduler/pod_task.go
+++ b/scheduler/pod_task.go
@@ -247,7 +247,7 @@ func (t *PodTask) UpdateDesiredState(manifest *api.ContainerManifest) error {
 	// port assignments just in case this task is re-scheduled later and
 	// we need access to the original manifest
 
-	// TODO(jdef): will this confuse some recification loop that wants to
+	// TODO(jdef): will this confuse some rectification loop that wants to
 	// ensure that desired state == running state?
 
 	if len(t.ports) > 0 {

--- a/scheduler/pod_task.go
+++ b/scheduler/pod_task.go
@@ -181,11 +181,8 @@ func rangeResource(name string, ports []uint64) *mesos.Resource {
 func NewRanges(ports []uint64) *mesos.Value_Ranges {
 	r := []*mesos.Value_Range{}
 	for _, port := range ports {
-		// this is subtle: since we're using pointers to the port we must not
-		// use the loop variable, otherwise the begin and end of all the ranges
-		// we construct will end up being exactly the same. so copy it to x
-		x := port
-		r = append(r, &mesos.Value_Range{Begin: &x, End: &x})
+		x := proto.Uint64(port)
+		r = append(r, &mesos.Value_Range{Begin: x, End: x})
 	}
 	return &mesos.Value_Ranges{Range: r}
 }

--- a/scheduler/pod_task_test.go
+++ b/scheduler/pod_task_test.go
@@ -58,8 +58,6 @@ func TestDefaultHostPortMatching(t *testing.T) {
 
 	offer := &mesos.Offer{
 		Resources: []*mesos.Resource{
-			mesos.ScalarResource("cpus", t_min_cpu),
-			mesos.ScalarResource("mem", t_min_mem),
 			rangeResource("ports", []uint64{1, 1}),
 		},
 	}
@@ -69,6 +67,26 @@ func TestDefaultHostPortMatching(t *testing.T) {
 	}
 	if len(mapping) > 0 {
 		t.Fatalf("Found mappings for a pod without ports: %v", pod)
+	}
+
+	//--
+	pod.DesiredState = api.PodState{
+		Manifest: api.ContainerManifest{
+			Containers: []api.Container{{
+				Ports: []api.Port{{
+					HostPort: 123,
+				}, {
+					HostPort: 123,
+				}},
+			}},
+		},
+	}
+	task, _ = newPodTask(pod, &mesos.ExecutorInfo{})
+	_, err = defaultHostPortMapping(task, offer)
+	if err, _ := err.(*DuplicateHostPortError); err == nil {
+		t.Fatal("Expected duplicate port error")
+	} else if err.m1.offerPort != 123 {
+		t.Fatal("Expected duplicate host port 123")
 	}
 }
 
@@ -122,5 +140,117 @@ func TestAcceptOfferPorts(t *testing.T) {
 	pod.DesiredState.Manifest.Containers[0].Ports[0].HostPort = 1
 	if ok := task.AcceptOffer(offer); ok {
 		t.Fatalf("accepted offer %v:", offer)
+	}
+}
+
+func TestWildcardHostPortMatching(t *testing.T) {
+	t.Parallel()
+	pod := &api.Pod{}
+	task, _ := newPodTask(pod, &mesos.ExecutorInfo{})
+
+	offer := &mesos.Offer{}
+	mapping, err := wildcardHostPortMapping(task, offer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mapping) > 0 {
+		t.Fatalf("Found mappings for an empty offer and a pod without ports: %v", pod)
+	}
+
+	//--
+	offer = &mesos.Offer{
+		Resources: []*mesos.Resource{
+			rangeResource("ports", []uint64{1, 1}),
+		},
+	}
+	mapping, err = wildcardHostPortMapping(task, offer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mapping) > 0 {
+		t.Fatalf("Found mappings for a pod without ports: %v", pod)
+	}
+
+	//--
+	pod.DesiredState = api.PodState{
+		Manifest: api.ContainerManifest{
+			Containers: []api.Container{{
+				Ports: []api.Port{{
+					HostPort: 123,
+				}},
+			}},
+		},
+	}
+	task, _ = newPodTask(pod, &mesos.ExecutorInfo{})
+	mapping, err = wildcardHostPortMapping(task, offer)
+	if err, _ := err.(*PortAllocationError); err == nil {
+		t.Fatal("Expected port allocation error")
+	} else if !(len(err.Ports) == 1 && err.Ports[0] == 123) {
+		t.Fatal("Expected port allocation error for host port 123")
+	}
+
+	//--
+	pod.DesiredState = api.PodState{
+		Manifest: api.ContainerManifest{
+			Containers: []api.Container{{
+				Ports: []api.Port{{
+					HostPort: 0,
+				}, {
+					HostPort: 123,
+				}},
+			}},
+		},
+	}
+	task, _ = newPodTask(pod, &mesos.ExecutorInfo{})
+	mapping, err = wildcardHostPortMapping(task, offer)
+	if err, _ := err.(*PortAllocationError); err == nil {
+		t.Fatal("Expected port allocation error")
+	} else if !(len(err.Ports) == 1 && err.Ports[0] == 123) {
+		t.Fatal("Expected port allocation error for host port 123")
+	}
+
+	//--
+	pod.DesiredState = api.PodState{
+		Manifest: api.ContainerManifest{
+			Containers: []api.Container{{
+				Ports: []api.Port{{
+					HostPort: 0,
+				}, {
+					HostPort: 1,
+				}},
+			}},
+		},
+	}
+	task, _ = newPodTask(pod, &mesos.ExecutorInfo{})
+	mapping, err = wildcardHostPortMapping(task, offer)
+	if err, _ := err.(*PortAllocationError); err == nil {
+		t.Fatal("Expected port allocation error")
+	} else if len(err.Ports) != 0 {
+		t.Fatal("Expected port allocation error for wildcard port")
+	}
+
+	//--
+	offer = &mesos.Offer{
+		Resources: []*mesos.Resource{
+			rangeResource("ports", []uint64{1, 2}),
+		},
+	}
+	mapping, err = wildcardHostPortMapping(task, offer)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(mapping) != 2 {
+		t.Fatal("Expected both ports allocated")
+	}
+	valid := 0
+	for _, entry := range mapping {
+		if entry.cindex == 0 && entry.pindex == 0 && entry.offerPort == 2 {
+			valid++
+		}
+		if entry.cindex == 0 && entry.pindex == 1 && entry.offerPort == 1 {
+			valid++
+		}
+	}
+	if valid < 2 {
+		t.Fatalf("Expected 2 valid port mappings, not %d", valid)
 	}
 }

--- a/scheduler/pod_task_test.go
+++ b/scheduler/pod_task_test.go
@@ -72,7 +72,7 @@ func TestDefaultHostPortMatching(t *testing.T) {
 	}
 }
 
-func TestNoMatchingPorts(t *testing.T) {
+func TestAcceptOfferPorts(t *testing.T) {
 	t.Parallel()
 	pod := &api.Pod{}
 	task, _ := newPodTask(pod, &mesos.ExecutorInfo{})

--- a/scheduler/pod_task_test.go
+++ b/scheduler/pod_task_test.go
@@ -1,0 +1,105 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/mesos/mesos-go/mesos"
+)
+
+const (
+	t_min_cpu	= 128
+	t_min_mem	= 128
+)
+
+func TestEmptyOffer(t *testing.T) {
+	t.Parallel()
+	task, err := newPodTask(&api.Pod{}, &mesos.ExecutorInfo{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok := task.AcceptOffer(nil); ok {
+		t.Fatalf("accepted nil offer")
+	}
+	if ok := task.AcceptOffer(&mesos.Offer{}); ok {
+		t.Fatalf("accepted empty offer")
+	}
+}
+
+func TestNoPortsInPodOrOffer(t *testing.T) {
+	t.Parallel()
+	task, _ := newPodTask(&api.Pod{}, &mesos.ExecutorInfo{})
+
+	offer := &mesos.Offer{
+		Resources: []*mesos.Resource{
+			mesos.ScalarResource("cpus", 0.001),
+			mesos.ScalarResource("mem", 0.001),
+		},
+	}
+	if ok := task.AcceptOffer(offer); ok {
+		t.Fatalf("accepted offer %v:", offer)
+	}
+
+	offer = &mesos.Offer{
+		Resources: []*mesos.Resource{
+			mesos.ScalarResource("cpus", t_min_cpu),
+			mesos.ScalarResource("mem", t_min_mem),
+		},
+	}
+	if ok := task.AcceptOffer(offer); !ok {
+		t.Fatalf("did not accepted offer %v:", offer)
+	}
+}
+
+func TestNoMatchingPorts(t *testing.T) {
+	t.Parallel()
+	pod := &api.Pod{}
+	task, _ := newPodTask(pod, &mesos.ExecutorInfo{})
+
+	offer := &mesos.Offer{
+		Resources: []*mesos.Resource{
+			mesos.ScalarResource("cpus", t_min_cpu),
+			mesos.ScalarResource("mem", t_min_mem),
+			rangeResource("ports", []uint64{1,1}),
+		},
+	}
+	if ok := task.AcceptOffer(offer); !ok {
+		t.Fatalf("did not accepted offer %v:", offer)
+	}
+
+	pod.DesiredState = api.PodState{
+		Manifest: api.ContainerManifest{
+			Containers: []api.Container{{
+				Ports: []api.Port{{
+					HostPort: 123,
+				}},
+			}},
+		},
+	}
+	if ok := task.AcceptOffer(offer); ok {
+		t.Fatalf("accepted offer %v:", offer)
+	}
+
+	pod.DesiredState.Manifest.Containers[0].Ports[0].HostPort = 1
+	if ok := task.AcceptOffer(offer); !ok {
+		t.Fatalf("did not accepted offer %v:", offer)
+	}
+
+	pod.DesiredState.Manifest.Containers[0].Ports[0].HostPort = 0
+	if ok := task.AcceptOffer(offer); !ok {
+		t.Fatalf("did not accepted offer %v:", offer)
+	}
+
+	offer.Resources = []*mesos.Resource{
+		mesos.ScalarResource("cpus", t_min_cpu),
+		mesos.ScalarResource("mem", t_min_mem),
+	}
+	if ok := task.AcceptOffer(offer); !ok {
+		t.Fatalf("did not accepted offer %v:", offer)
+	}
+
+	pod.DesiredState.Manifest.Containers[0].Ports[0].HostPort = 1
+	if ok := task.AcceptOffer(offer); ok {
+		t.Fatalf("accepted offer %v:", offer)
+	}
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -21,7 +21,6 @@ import (
 	plugin "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler"
 	log "github.com/golang/glog"
 	"github.com/mesos/mesos-go/mesos"
-	"gopkg.in/v1/yaml"
 )
 
 const (
@@ -703,13 +702,7 @@ func (k *KubernetesScheduler) prepareTaskForLaunch(machine string, task *PodTask
 	// pod containers will use for service discovery. the kubelet-executor uses this
 	// manifest to instantiate the pods and this is the last update we make before
 	// firing up the pod.
-	task.Pod.DesiredState.Manifest = manifest
-	task.TaskInfo.Data, err = yaml.Marshal(&manifest)
-	if err != nil {
-		log.V(2).Infof("Failed to marshal the updated manifest")
-		return err
-	}
-	return nil
+	return task.UpdateDesiredState(&manifest)
 }
 
 // Update an existing pod.


### PR DESCRIPTION
This branch attempts to implement a solution for #59.

A special label `k8sm:expose` may be used to auto-publish a container port to the host, using any non-conflicting port in a mesos resource offer. Non-conflicting means that (a) it's in the "ports" resource range of the offer, and; (b) no other container in the pod has directly specified that pod as its HostPort.

`k8sm:expose` currently accepts a single value `'*'`, which auto-publishes all container ports with HostPort == 0 (wildcard ports). Current thinking is that the value of this label could also be a comma-delimited list of Port.ContainerPort's (int or string) to which the auto-publish rule would be applied.

TODOs:
- [ ] endpoint controller currently uses DesiredState to derive endpoints: this is a **problem** because currently the pod_task implementation (purposefully) doesn't overwrite DesiredState, which means that findPort() will return 0 for wildcard ports -- not good. perhaps our implementation of endpoint controller could query /boundPods on the kubelet? (would need to wait for rebase to 05x (see #88)). **Alternative:** "filter" the GetPods and ListPods results, updating the DesiredState and CurrentState for all returned objects such that wildcard host port overrides are updated on the fly. This makes the endpoint controller happy, and allows us to keep a "cleanroom" DesiredState spec stored with the task.
- [x] consider `k8sm/expose` as an alternative label? there seems to be a tendency in k8s for using `'/'` as a delimiter for other things.