### PR TITLE
Constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _test
 third_party
 bin
 _build
+.vagrant
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.3
   - 1.4
 
 install:

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/mesosphere/kubernetes-mesos",
-	"GoVersion": "go1.3.3",
+	"GoVersion": "go1.4.2",
 	"Packages": [
 		"./..."
 	],

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ DESTDIR		?= /target
 TAGS		?=
 
 BUILDDIR	?= $(current_dir)/_build
-GOPATH		?= $(shell uname | grep -e ^CYGWIN >/dev/null && cygpath --mixed "$(BUILDDIR)" || "$(BUILDDIR)")
+GOPATH		:= $(shell uname | grep -e ^CYGWIN >/dev/null && cygpath --mixed "$(BUILDDIR)" || echo -E "$(BUILDDIR)")
 
 .PHONY: all error require-godep require-vendor install info bootstrap format test patch version test.v test.vv clean lint vet fix prepare
 

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,11 @@ vet fix:
 test test.v:
 	test "$@" = "test.v" && args="-test.v" || args=""; \
 		test -n "$(WITH_RACE)" && args="$$args -race" || true; \
-		env GOPATH=$(GOPATH) go test $$args $(TESTS:%=${K8SM_GO_PACKAGE}/%)
+		env GOPATH=$(GOPATH) go test $$args -tags unit_test $(TESTS:%=${K8SM_GO_PACKAGE}/%)
 
 test.vv:
 	test -n "$(WITH_RACE)" && args="$$args -race" || args=""; \
-		env GOPATH=$(GOPATH) go test -test.v $$args $(TESTS:%=${K8SM_GO_PACKAGE}/%) -logtostderr=true -vmodule=$(TESTS_VV)
+		env GOPATH=$(GOPATH) go test -test.v $$args -tags unit_test $(TESTS:%=${K8SM_GO_PACKAGE}/%) -logtostderr=true -vmodule=$(TESTS_VV)
 
 install: all
 	mkdir -p $(DESTDIR)

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ K8S_CMD		:= \
                    ${KUBE_GO_PACKAGE}/cmd/kube-apiserver	\
                    ${KUBE_GO_PACKAGE}/cmd/kube-proxy
 
-CMD_DIRS := $(shell cd $(current_dir) && find ./cmd -type f -name '*.go'|sort|while read f; do echo -E "$$(dirname "$$f")"; done|sort|uniq|cut -f1 -d/ --complement)
+CMD_DIRS := $(shell cd $(current_dir) && find ./cmd -type f -name '*.go'|sort|while read f; do echo -E "$$(dirname "$$f")"; done|sort|uniq|sed -e 's~^[^/]*/~~g')
 
 FRAMEWORK_CMD	:= ${CMD_DIRS:%=${K8SM_GO_PACKAGE}/%}
 
-LIB_DIRS := $(shell cd $(current_dir) && find ./pkg -type f -name '*.go'|sort|while read f; do echo -E "$$(dirname "$$f")"; done|sort|uniq|cut -f1 -d/ --complement)
+LIB_DIRS := $(shell cd $(current_dir) && find ./pkg -type f -name '*.go'|sort|while read f; do echo -E "$$(dirname "$$f")"; done|sort|uniq|sed -e 's~^[^/]*/~~g')
 
 FRAMEWORK_LIB	:= ${LIB_DIRS:%=${K8SM_GO_PACKAGE}/%}
 TESTS_LOGV	?= 2
@@ -28,6 +28,9 @@ TESTS_VV        = $(shell for pkg in $(TESTS); do ls $$pkg/*.go | while read -r 
 GIT_VERSION_FILE := $(current_dir)/.kube-version
 
 SHELL		:= /bin/bash
+
+# applying patches requires bash 4+ so this variable may be specified with a full path to a newer version of the bash
+ALT_BASH_SHELL	?= /usr/local/bin/bash
 
 # a list of upstream projects for which we test the availability of patches
 PATCH_SCRIPT	:= $(current_dir)/hack/patches/apply.sh
@@ -112,7 +115,7 @@ prepare:
 	(xdir=$$(dirname $(BUILDDIR)/src/$(K8SM_GO_PACKAGE)); mkdir -p $$xdir && cd $$xdir && ln -s $(current_dir) $$(basename $(K8SM_GO_PACKAGE)))
 
 patch: prepare $(PATCH_SCRIPT)
-	env GOPATH=$(GOPATH) $(PATCH_SCRIPT)
+	env GOPATH=$(GOPATH) USR_LOCAL_BASH=$(ALT_BASH_SHELL) $(PATCH_SCRIPT)
 
 version: $(GIT_VERSION_FILE)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ docker run --rm -v $(pwd)/bin:/target mesosphere/kubernetes-mesos:build
 To build from source follow the instructions below.
 Before building anything please review all of the instructions, including any environment setup steps that may be required prior to the actual build.
 
-**NOTE:** Building Kubernetes for Mesos requires Go 1.3+.
+**NOTE:** Building Kubernetes for Mesos requires Go 1.4+.
 * See the [development][1] page for sample environment setup steps.
 
 Kubernetes-Mesos is built using a Makefile to automate the process of patching the vanilla Kubernetes code.

--- a/hack/patches/apply.sh
+++ b/hack/patches/apply.sh
@@ -6,7 +6,11 @@ function die() {
 }
 
 test -n "$GOPATH" || die Missing GOPATH
-pkg="${GOPATH%%:*}"
+uname|grep -e ^CYGWIN >/dev/null 2>&1 && {
+	pkg="${GOPATH%%;*}"
+} || {
+	pkg="${GOPATH%%:*}"
+}
 echo GO packages in $pkg will be patched
 
 test -n "$pkg" || die Invalid GOPATH=$GOPATH

--- a/pkg/offers/offers.go
+++ b/pkg/offers/offers.go
@@ -85,6 +85,9 @@ type offerSpec struct {
 	hostname string
 }
 
+// offers that may perish (all of them?) implement this interface.
+// callers may expect to access these funcs concurrently so implementations
+// must provide their own form of synchronization around mutable state.
 type Perishable interface {
 	// returns true if this offer has expired
 	HasExpired() bool

--- a/pkg/offers/offers.go
+++ b/pkg/offers/offers.go
@@ -12,6 +12,7 @@ import (
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	"github.com/mesosphere/kubernetes-mesos/pkg/offers/metrics"
 	"github.com/mesosphere/kubernetes-mesos/pkg/queue"
+	"github.com/mesosphere/kubernetes-mesos/pkg/runtime"
 )
 
 const (
@@ -454,7 +455,7 @@ func (s *offerStorage) notifyListeners(ids func() (util.StringSet, uint64)) {
 
 func (s *offerStorage) Init(done <-chan struct{}) {
 	// zero delay, reap offers as soon as they expire
-	go util.Until(s.ageOffers, 0, done)
+	go runtime.Until(s.ageOffers, 0, done)
 
 	// cached offer ids for the purposes of listener notification
 	idCache := &stringsCache{
@@ -470,7 +471,7 @@ func (s *offerStorage) Init(done <-chan struct{}) {
 		ttl: offerIdCacheTTL,
 	}
 
-	go util.Until(func() { s.notifyListeners(idCache.Strings) }, notifyListenersDelay, done)
+	go runtime.Until(func() { s.notifyListeners(idCache.Strings) }, notifyListenersDelay, done)
 }
 
 type stringsCache struct {

--- a/pkg/proc/errors.go
+++ b/pkg/proc/errors.go
@@ -5,9 +5,10 @@ import (
 )
 
 var (
-	errActionNotAllowed  = errors.New("action is not permitted to run")
-	errProcessTerminated = errors.New("cannot execute action because process has terminated")
-	errIllegalState      = errors.New("illegal state, cannot execute action")
+	errActionNotAllowed      = errors.New("action is not permitted to run")
+	errProcessTerminated     = errors.New("cannot execute action because process has terminated")
+	errIllegalState          = errors.New("illegal state, cannot execute action")
+	errActionScheduleTimeout = errors.New("timed out attempting to schedule action for deferred execution")
 )
 
 func IsActionNotAllowed(err error) bool {
@@ -20,4 +21,8 @@ func IsProcessTerminated(err error) bool {
 
 func IsIllegalState(err error) bool {
 	return err == errIllegalState
+}
+
+func IsActionScheduleTimeout(err error) bool {
+	return err == errActionScheduleTimeout
 }

--- a/pkg/proc/errors.go
+++ b/pkg/proc/errors.go
@@ -5,15 +5,10 @@ import (
 )
 
 var (
-	errActionNotAllowed      = errors.New("action is not permitted to run")
 	errProcessTerminated     = errors.New("cannot execute action because process has terminated")
 	errIllegalState          = errors.New("illegal state, cannot execute action")
 	errActionScheduleTimeout = errors.New("timed out attempting to schedule action for deferred execution")
 )
-
-func IsActionNotAllowed(err error) bool {
-	return err == errActionNotAllowed
-}
 
 func IsProcessTerminated(err error) bool {
 	return err == errProcessTerminated

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -114,17 +114,17 @@ func DoAndWait(p Process, a Action) error {
 // no two actions should execute at the same time. invocations of this func
 // should never block.
 // returns errProcessTerminated if the process already ended.
-func (self *procImpl) DoLater(a Action) (err error) {
+func (self *procImpl) DoLater(deferredAction Action) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			defer self.End()
 			err = fmt.Errorf("attempted to schedule action on a closed process backlog: %v", r)
 		}
 	}()
-	a = Action(func() {
+	a := Action(func() {
 		self.wg.Add(1)
 		defer self.wg.Done()
-		a()
+		deferredAction()
 	})
 	select {
 	case <-self.terminate:

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1,0 +1,110 @@
+package proc
+
+import (
+	"testing"
+	"time"
+
+	log "github.com/golang/glog"
+)
+
+func TestProc_manyEndings(t *testing.T) {
+	p := New()
+	p.End()
+	p.End()
+	p.End()
+	p.End()
+	p.End()
+	select {
+	case <-p.Done():
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for process death")
+	}
+}
+
+func TestProc_neverBegun(t *testing.T) {
+	p := New()
+	select {
+	case <-p.Done():
+		t.Fatalf("expected to time out waiting for process death")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+func TestProc_halflife(t *testing.T) {
+	p := New()
+	p.End()
+	select {
+	case <-p.Done():
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for process death")
+	}
+}
+
+func TestProc_beginTwice(t *testing.T) {
+	p := New()
+	p.Begin()
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("expected panic because Begin() was invoked more than once")
+			}
+		}()
+		p.Begin() // should be ignored
+	}()
+	p.End()
+	select {
+	case <-p.Done():
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for process death")
+	}
+}
+
+func TestProc_singleAction(t *testing.T) {
+	p := New()
+	p.Begin()
+	scheduled := make(chan struct{})
+	called := make(chan struct{})
+
+	go func() {
+		log.Infof("do'ing deferred action")
+		defer close(scheduled)
+		err := p.Do(func() {
+			defer close(called)
+			log.Infof("deferred action invoked")
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}()
+
+	select {
+	case <-scheduled:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for deferred action to be scheduled")
+	}
+
+	select {
+	case <-called:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for deferred action to be invoked")
+	}
+
+	p.End()
+
+	select {
+	case <-p.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for process death")
+	}
+}
+
+func TestProc_goodLifecycle(t *testing.T) {
+	p := New()
+	p.Begin()
+	p.End()
+	select {
+	case <-p.Done():
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for process death")
+	}
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1,6 +1,7 @@
 package proc
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -87,6 +88,51 @@ func TestProc_singleAction(t *testing.T) {
 	case <-called:
 	case <-time.After(1 * time.Second):
 		t.Fatalf("timed out waiting for deferred action to be invoked")
+	}
+
+	p.End()
+
+	select {
+	case <-p.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for process death")
+	}
+}
+
+func TestProc_multiAction(t *testing.T) {
+	p := New()
+	p.Begin()
+	const COUNT = 10
+	var called sync.WaitGroup
+	called.Add(COUNT)
+
+	// test FIFO property
+	next := 0
+	for i := 0; i < COUNT; i++ {
+		log.Infof("do'ing deferred action %d", i)
+		idx := i
+		err := p.Do(func() {
+			defer called.Done()
+			log.Infof("deferred action invoked")
+			if next != idx {
+				t.Fatalf("expected index %d instead of %d", idx, next)
+			}
+			next++
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		called.Wait()
+	}()
+	select {
+	case <-ch:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for deferred actions to be invoked")
 	}
 
 	p.End()

--- a/pkg/proc/state.go
+++ b/pkg/proc/state.go
@@ -1,0 +1,39 @@
+package proc
+
+import (
+	"sync/atomic"
+)
+
+type stateType int32
+
+const (
+	stateNew stateType = iota
+	stateRunning
+	stateTerminal
+)
+
+func (s *stateType) get() stateType {
+	return stateType(atomic.LoadInt32((*int32)(s)))
+}
+
+func (s *stateType) transition(from, to stateType) bool {
+	return atomic.CompareAndSwapInt32((*int32)(s), int32(from), int32(to))
+}
+
+func (s *stateType) transitionTo(to stateType, unless ...stateType) bool {
+	if len(unless) == 0 {
+		atomic.StoreInt32((*int32)(s), int32(to))
+		return true
+	}
+	for {
+		state := s.get()
+		for _, x := range unless {
+			if state == x {
+				return false
+			}
+		}
+		if s.transition(state, to) {
+			return true
+		}
+	}
+}

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -11,18 +11,18 @@ type Context interface {
 }
 
 type Doer interface {
-	// execute some action in the context of the current process. actions
-	// executed via this func are to be executed in a concurrency-safe manner:
-	// no two actions should execute at the same time.
-	//
+	// execute some action in some context. actions are to be executed in a
+	// concurrency-safe manner: no two actions should execute at the same time.
 	// errors are generated if the action cannot be executed (not by the execution
-	// of the action) and may be tested with, for example, IsActionNotAllowedError.
+	// of the action) and should be testable with the error API of this package,
+	// for example, IsProcessTerminated.
 	Do(Action) error
 }
 
 // adapter func for Doer interface
 type DoerFunc func(Action) error
 
+// invoke the f on action a. returns an illegal state error if f is nil.
 func (f DoerFunc) Do(a Action) error {
 	if f != nil {
 		return f(a)
@@ -38,6 +38,6 @@ type Process interface {
 type ProcessInit interface {
 	Process
 
-	// begin process accounting and spawn background routines
+	// begin process accounting and spawn requisite background routines
 	Begin()
 }

--- a/pkg/runtime/latch.go
+++ b/pkg/runtime/latch.go
@@ -1,0 +1,19 @@
+package runtime
+
+import (
+	"sync/atomic"
+)
+
+type Latch struct {
+	int32
+}
+
+// return true if this latch was successfully acquired. concurrency safe. will only return true
+// upon the first invocation, all subsequent invocations will return false. always returns false
+// when self is nil.
+func (self *Latch) Acquire() bool {
+	if self == nil {
+		return false
+	}
+	return atomic.CompareAndSwapInt32(&self.int32, 0, 1)
+}

--- a/pkg/runtime/metrics.go
+++ b/pkg/runtime/metrics.go
@@ -1,0 +1,31 @@
+package runtime
+
+import (
+	"sync"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	runtimeSubsystem = "runtime"
+)
+
+var (
+	panicCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: runtimeSubsystem,
+			Name:      "panics",
+			Help:      "Counter of panics handled by the internal crash handler.",
+		},
+	)
+)
+
+var registerMetrics sync.Once
+
+func Register() {
+	registerMetrics.Do(func() {
+		prometheus.MustRegister(panicCounter)
+		util.PanicHandlers = append(util.PanicHandlers, func(interface{}) { panicCounter.Inc() })
+	})
+}

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -64,12 +64,12 @@ func Until(f func(), period time.Duration, stopCh <-chan struct{}) {
 	if f == nil {
 		return
 	}
-	select {
-	case <-stopCh:
-		return
-	default:
-	}
 	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
 		func() {
 			defer util.HandleCrash()
 			f()

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -9,21 +9,15 @@ import (
 
 type Signal <-chan struct{}
 
-/* TODO(jdef) not very useful without execution conditional on errors
 // upon receiving signal sig invoke function f and immediately return a signal
-// that indicates f's completion.
+// that indicates f's completion. used to chain handler funcs, for example:
+//    On(job.Done(), response.Send).Then(wg.Done)
 func (sig Signal) Then(f func()) Signal {
 	if sig == nil {
 		return nil
 	}
-	ch := make(chan struct{})
-	On(sig, func() {
-		defer close(ch)
-		f()
-	})
-	return Signal(ch)
+	return On(sig, f)
 }
-*/
 
 // execute a callback function after the specified signal chan closes.
 // immediately returns a signal that indicates f's completion.
@@ -64,6 +58,8 @@ func Go(f func()) Signal {
 	return Signal(ch)
 }
 
+// periodically execute the given function, stopping once stopCh is closed.
+// this func blocks until stopCh is closed, it's intended to be run as a goroutine.
 func Until(f func(), period time.Duration, stopCh <-chan struct{}) {
 	if f == nil {
 		return

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -32,7 +32,9 @@ func On(sig <-chan struct{}, f func()) Signal {
 	}
 	return Go(func() {
 		<-sig
-		f()
+		if f != nil {
+			f()
+		}
 	})
 }
 
@@ -41,20 +43,22 @@ func OnOSSignal(sig <-chan os.Signal, f func(os.Signal)) Signal {
 		return nil
 	}
 	return Go(func() {
-		if s, ok := <-sig; ok {
+		if s, ok := <-sig; ok && f != nil {
 			f(s)
 		}
 	})
 }
 
 // spawn a goroutine to execute a func, immediately returns a chan that closes
-// upon completion of the func.
+// upon completion of the func. returns a nil signal chan if the given func is nil.
 func Go(f func()) Signal {
 	ch := make(chan struct{})
 	go func() {
 		defer close(ch)
 		defer util.HandleCrash()
-		f()
+		if f != nil {
+			f()
+		}
 	}()
 	return Signal(ch)
 }

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -1,0 +1,60 @@
+package runtime
+
+import (
+	"os"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+type Signal <-chan struct{}
+
+/* TODO(jdef) not very useful without execution conditional on errors
+// upon receiving signal sig invoke function f and immediately return a signal
+// that indicates f's completion.
+func (sig Signal) Then(f func()) Signal {
+	if sig == nil {
+		return nil
+	}
+	ch := make(chan struct{})
+	On(sig, func() {
+		defer close(ch)
+		f()
+	})
+	return Signal(ch)
+}
+*/
+
+// execute a callback function after the specified signal chan closes.
+// immediately returns a signal that indicates f's completion.
+func On(sig <-chan struct{}, f func()) Signal {
+	if sig == nil {
+		return nil
+	}
+	return Go(func() {
+		<-sig
+		f()
+	})
+}
+
+func OnOSSignal(sig <-chan os.Signal, f func(os.Signal)) Signal {
+	if sig == nil {
+		return nil
+	}
+	return Go(func() {
+		if s, ok := <-sig; ok {
+			f(s)
+		}
+	})
+}
+
+// spawn a goroutine to execute a func, immediately returns a chan that closes
+// upon completion of the func.
+func Go(f func()) Signal {
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		defer util.HandleCrash()
+		f()
+	}()
+	return Signal(ch)
+}

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"os"
+	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -61,4 +62,25 @@ func Go(f func()) Signal {
 		}
 	}()
 	return Signal(ch)
+}
+
+func Until(f func(), period time.Duration, stopCh <-chan struct{}) {
+	if f == nil {
+		return
+	}
+	select {
+	case <-stopCh:
+		return
+	default:
+	}
+	for {
+		func() {
+			defer util.HandleCrash()
+			f()
+		}()
+		select {
+		case <-stopCh:
+		case <-time.After(period):
+		}
+	}
 }

--- a/pkg/scheduler/constraint/constraint.go
+++ b/pkg/scheduler/constraint/constraint.go
@@ -1,0 +1,90 @@
+package constraint
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type OperatorType int
+
+const (
+	UniqueOperator OperatorType = iota
+	LikeOperator
+	ClusterOperator
+	GroupByOperator
+	UnlikeOperator
+)
+
+var (
+	labels = []string{
+		"UNIQUE",
+		"LIKE",
+		"CLUSTER",
+		"GROUP_BY",
+		"UNLIKE",
+	}
+
+	labelToType map[string]OperatorType
+)
+
+func init() {
+	labelToType = make(map[string]OperatorType)
+	for i, s := range labels {
+		labelToType[s] = OperatorType(i)
+	}
+}
+
+func (t OperatorType) String() string {
+	switch t {
+	case UniqueOperator, LikeOperator, ClusterOperator, GroupByOperator, UnlikeOperator:
+		return labels[int(t)]
+	default:
+		panic(fmt.Sprintf("unrecognized operator type: %d", int(t)))
+	}
+}
+
+func parseOperatorType(s string) (OperatorType, error) {
+	t, found := labelToType[s]
+	if !found {
+		return UniqueOperator, fmt.Errorf("unrecognized operator %q", s)
+	}
+	return t, nil
+}
+
+type Constraint struct {
+	Field    string       // required
+	Operator OperatorType // required
+	Value    string       // optional
+}
+
+func (c *Constraint) MarshalJSON() ([]byte, error) {
+	var a []string
+	if c != nil {
+		if c.Value != "" {
+			a = append(a, c.Field, c.Operator.String(), c.Value)
+		} else {
+			a = append(a, c.Field, c.Operator.String())
+		}
+	}
+	return json.Marshal(a)
+}
+
+func (c *Constraint) UnmarshalJSON(buf []byte) (err error) {
+	var a []string
+	if err = json.Unmarshal(buf, &a); err != nil {
+		return err
+	}
+	switch x := len(a); {
+	case x < 2:
+		err = fmt.Errorf("not enough arguments to form constraint")
+	case x > 3:
+		err = fmt.Errorf("too many arguments to form constraint")
+	case x == 3:
+		c.Value = a[2]
+		fallthrough
+	case x == 2:
+		c.Field = a[0]
+		c.Operator, err = parseOperatorType(a[1])
+	}
+	return err
+}

--- a/pkg/scheduler/constraint/constraint_test.go
+++ b/pkg/scheduler/constraint/constraint_test.go
@@ -1,0 +1,63 @@
+package constraint
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDeserialize(t *testing.T) {
+	shouldMatch := func(js string, field string, operator OperatorType, value string) (err error) {
+		constraint := Constraint{}
+		if err = json.Unmarshal(([]byte)(js), &constraint); err != nil {
+			return
+		}
+		if field != constraint.Field {
+			t.Fatalf("expected field %q instead of %q", field, constraint.Field)
+		}
+		if operator != constraint.Operator {
+			t.Fatalf("expected operator %v instead of %v", operator, constraint.Operator)
+		}
+		if value != constraint.Value {
+			t.Fatalf("expected value %q instead of %q", value, constraint.Value)
+		}
+		return
+	}
+	failOnError := func(err error) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	failOnError(shouldMatch(`["hostname","UNIQUE"]`, "hostname", UniqueOperator, ""))
+	failOnError(shouldMatch(`["rackid","GROUP_BY","1"]`, "rackid", GroupByOperator, "1"))
+	failOnError(shouldMatch(`["jdk","LIKE","7"]`, "jdk", LikeOperator, "7"))
+	failOnError(shouldMatch(`["jdk","UNLIKE","7"]`, "jdk", UnlikeOperator, "7"))
+	failOnError(shouldMatch(`["bob","CLUSTER","foo"]`, "bob", ClusterOperator, "foo"))
+	err := shouldMatch(`["bill","NOT_REALLY_AN_OPERATOR","pete"]`, "bill", ClusterOperator, "pete")
+	if err == nil {
+		t.Fatalf("expected unmarshalling error for invalid operator")
+	}
+}
+
+func TestSerialize(t *testing.T) {
+	shouldMatch := func(expected string, constraint *Constraint) error {
+		data, err := json.Marshal(constraint)
+		if err != nil {
+			return err
+		}
+		js := string(data)
+		if js != expected {
+			t.Fatalf("expected json %q instead of %q", expected, js)
+		}
+		return nil
+	}
+	failOnError := func(err error) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	failOnError(shouldMatch(`["hostname","UNIQUE"]`, &Constraint{"hostname", UniqueOperator, ""}))
+	failOnError(shouldMatch(`["rackid","GROUP_BY","1"]`, &Constraint{"rackid", GroupByOperator, "1"}))
+	failOnError(shouldMatch(`["jdk","LIKE","7"]`, &Constraint{"jdk", LikeOperator, "7"}))
+	failOnError(shouldMatch(`["jdk","UNLIKE","7"]`, &Constraint{"jdk", UnlikeOperator, "7"}))
+	failOnError(shouldMatch(`["bob","CLUSTER","foo"]`, &Constraint{"bob", ClusterOperator, "foo"}))
+}

--- a/pkg/scheduler/fcfs.go
+++ b/pkg/scheduler/fcfs.go
@@ -21,11 +21,7 @@ func FCFSScheduleFunc(r offers.Registry, unused SlaveIndex, task *podtask.T) (of
 		task.Reset()
 	}
 
-	// avoid this lookup unless we're logging it
-	podName := func() string {
-		pod := task.Pod()
-		return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-	}
+	podName := fmt.Sprintf("%s/%s", task.Pod.Namespace, task.Pod.Name)
 	var acceptedOffer offers.Perishable
 	err := r.Walk(func(p offers.Perishable) (bool, error) {
 		offer := p.Details()
@@ -35,7 +31,7 @@ func FCFSScheduleFunc(r offers.Registry, unused SlaveIndex, task *podtask.T) (of
 		if task.AcceptOffer(offer) {
 			if p.Acquire() {
 				acceptedOffer = p
-				log.V(3).Infof("Pod %s accepted offer %v", podName(), offer.Id.GetValue())
+				log.V(3).Infof("Pod %s accepted offer %v", podName, offer.Id.GetValue())
 				return true, nil // stop, we found an offer
 			}
 		}
@@ -48,9 +44,9 @@ func FCFSScheduleFunc(r offers.Registry, unused SlaveIndex, task *podtask.T) (of
 		return acceptedOffer, nil
 	}
 	if err != nil {
-		log.V(2).Infof("failed to find a fit for pod: %s, err = %v", podName(), err)
+		log.V(2).Infof("failed to find a fit for pod: %s, err = %v", podName, err)
 		return nil, err
 	}
-	log.V(2).Infof("failed to find a fit for pod: %s", podName())
+	log.V(2).Infof("failed to find a fit for pod: %s", podName)
 	return nil, noSuitableOffersErr
 }

--- a/pkg/scheduler/fcfs.go
+++ b/pkg/scheduler/fcfs.go
@@ -10,17 +10,6 @@ import (
 
 // A first-come-first-serve scheduler: acquires the first offer that can support the task
 func FCFSScheduleFunc(r offers.Registry, unused SlaveIndex, task *podtask.T) (offers.Perishable, error) {
-	if task.HasAcceptedOffer() {
-		// verify that the offer is still on the table
-		offerId := task.GetOfferId()
-		if offer, ok := r.Get(offerId); ok && !offer.HasExpired() {
-			// skip tasks that have already have assigned offers
-			return task.Offer, nil
-		}
-		task.Offer.Release()
-		task.Reset()
-	}
-
 	podName := fmt.Sprintf("%s/%s", task.Pod.Namespace, task.Pod.Name)
 	var acceptedOffer offers.Perishable
 	err := r.Walk(func(p offers.Perishable) (bool, error) {

--- a/pkg/scheduler/ha/ha.go
+++ b/pkg/scheduler/ha/ha.go
@@ -102,8 +102,10 @@ func (self *SchedulerProcess) Elect(newDriver DriverFactory) {
 			self.End()
 			return
 		}
+		log.V(1).Infoln("starting driver...")
 		stat, err := drv.Start()
 		if stat == mesos.Status_DRIVER_RUNNING && err == nil {
+			log.Infoln("driver started successfully and is running")
 			close(self.elected)
 			go func() {
 				defer self.End()

--- a/pkg/scheduler/mock_test.go
+++ b/pkg/scheduler/mock_test.go
@@ -43,16 +43,6 @@ func (m *MockScheduler) createPodTask(ctx api.Context, pod *api.Pod) (task *podt
 	err = args.Error(1)
 	return
 }
-func (m *MockScheduler) getTask(taskId string) (task *podtask.T, currentState podtask.StateType) {
-	args := m.Called(taskId)
-	x := args.Get(0)
-	if x != nil {
-		task = x.(*podtask.T)
-	}
-	y := args.Get(1)
-	currentState = y.(podtask.StateType)
-	return
-}
 func (m *MockScheduler) offers() (f offers.Registry) {
 	args := m.Called()
 	x := args.Get(0)
@@ -61,23 +51,13 @@ func (m *MockScheduler) offers() (f offers.Registry) {
 	}
 	return
 }
-func (m *MockScheduler) registerPodTask(tin *podtask.T, ein error) (tout *podtask.T, eout error) {
-	args := m.Called(tin, ein)
+func (m *MockScheduler) tasks() (f podtask.Registry) {
+	args := m.Called()
 	x := args.Get(0)
 	if x != nil {
-		tout = x.(*podtask.T)
+		f = x.(podtask.Registry)
 	}
-	eout = args.Error(1)
 	return
-}
-func (m *MockScheduler) taskForPod(podID string) (taskID string, ok bool) {
-	args := m.Called(podID)
-	taskID = args.String(0)
-	ok = args.Bool(1)
-	return
-}
-func (m *MockScheduler) unregisterPodTask(task *podtask.T) {
-	m.Called(task)
 }
 func (m *MockScheduler) killTask(taskId string) error {
 	args := m.Called(taskId)

--- a/pkg/scheduler/plugin.go
+++ b/pkg/scheduler/plugin.go
@@ -176,7 +176,7 @@ func (b *binder) bind(ctx api.Context, binding *api.Binding, task *podtask.T) (e
 	}
 
 	if err = b.prepareTaskForLaunch(ctx, binding.Host, task, offerId); err == nil {
-		log.V(2).Infof("launching task : %v", task)
+		log.V(2).Infof("launching task: %v on slave %v for pod %v/%v", task.ID, task.Spec.SlaveID, task.Pod.Namespace, task.Pod.Name)
 		if err = b.api.launchTask(task); err == nil {
 			b.api.offers().Invalidate(offerId)
 			task.Set(podtask.Launched)

--- a/pkg/scheduler/plugin.go
+++ b/pkg/scheduler/plugin.go
@@ -153,7 +153,7 @@ func (b *binder) Bind(binding *api.Binding) error {
 func (b *binder) rollback(task *podtask.T, err error) error {
 	task.Offer.Release()
 	task.Reset()
-	if _, err2 := b.api.tasks().Update(task); err2 != nil {
+	if err2 := b.api.tasks().Update(task); err2 != nil {
 		log.Errorf("failed to update pod task: %v", err2)
 	}
 	return err
@@ -180,7 +180,7 @@ func (b *binder) bind(ctx api.Context, binding *api.Binding, task *podtask.T) (e
 		if err = b.api.launchTask(task); err == nil {
 			b.api.offers().Invalidate(offerId)
 			task.Set(podtask.Launched)
-			if _, err = b.api.tasks().Update(task); err != nil {
+			if err = b.api.tasks().Update(task); err != nil {
 				// this should only happen if the task has been removed or has changed status,
 				// which SHOULD NOT HAPPEN as long as we're synchronizing correctly
 				log.Errorf("failed to update task w/ Launched status: %v", err)
@@ -332,7 +332,7 @@ func (k *kubeScheduler) doSchedule(task *podtask.T, err error) (string, error) {
 		} else {
 			task.Offer.Release()
 			task.Reset()
-			if _, err = k.api.tasks().Update(task); err != nil {
+			if err = k.api.tasks().Update(task); err != nil {
 				return "", err
 			}
 		}
@@ -359,7 +359,7 @@ func (k *kubeScheduler) doSchedule(task *podtask.T, err error) (string, error) {
 		}
 		task.Offer = offer
 		task.FillFromDetails(details)
-		if _, err := k.api.tasks().Update(task); err != nil {
+		if err := k.api.tasks().Update(task); err != nil {
 			offer.Release()
 			return "", err
 		}
@@ -640,7 +640,7 @@ func (k *deleter) deleteOne(pod *Pod) error {
 				task.Reset()
 				task.Set(podtask.Deleted)
 				//TODO(jdef) probably want better handling here
-				if _, err := k.api.tasks().Update(task); err != nil {
+				if err := k.api.tasks().Update(task); err != nil {
 					return err
 				}
 			}
@@ -652,7 +652,7 @@ func (k *deleter) deleteOne(pod *Pod) error {
 	case podtask.StateRunning:
 		// signal to watchers that the related pod is going down
 		task.Set(podtask.Deleted)
-		if _, err := k.api.tasks().Update(task); err != nil {
+		if err := k.api.tasks().Update(task); err != nil {
 			log.Errorf("failed to update task w/ Deleted status: %v", err)
 		}
 		return k.api.killTask(task.ID)

--- a/pkg/scheduler/plugin.go
+++ b/pkg/scheduler/plugin.go
@@ -433,7 +433,7 @@ func (q *queuer) reoffer(pod *Pod) {
 // spawns a go-routine to watch for unscheduled pods and queue them up
 // for scheduling. returns immediately.
 func (q *queuer) Run(done <-chan struct{}) {
-	go util.Until(func() {
+	go runtime.Until(func() {
 		log.Info("Watching for newly created pods")
 		q.lock.Lock()
 		defer q.lock.Unlock()
@@ -588,7 +588,7 @@ type deleter struct {
 // currently monitors for "pod deleted" events, upon which handle()
 // is invoked.
 func (k *deleter) Run(updates <-chan queue.Entry, done <-chan struct{}) {
-	go util.Until(func() {
+	go runtime.Until(func() {
 		for {
 			entry := <-updates
 			pod := entry.Value().(*Pod)

--- a/pkg/scheduler/plugin_test.go
+++ b/pkg/scheduler/plugin_test.go
@@ -87,7 +87,7 @@ func TestDeleteOne_Running(t *testing.T) {
 	}
 
 	task.Set(podtask.Launched)
-	_, err = reg.Update(task)
+	err = reg.Update(task)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/scheduler/podtask/debug.go
+++ b/pkg/scheduler/podtask/debug.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 
 	log "github.com/golang/glog"
 )
@@ -12,26 +11,20 @@ import (
 //TODO(jdef) we use a Locker to guard against concurrent task state changes, but it would be
 //really, really nice to avoid doing this. Maybe someday the registry won't return data ptrs
 //but plain structs instead.
-func InstallDebugHandlers(l sync.Locker, reg Registry) {
+func InstallDebugHandlers(reg Registry) {
 	http.HandleFunc("/debug/registry/tasks", func(w http.ResponseWriter, r *http.Request) {
 		//TODO(jdef) support filtering tasks based on status
 		alltasks := reg.List(nil)
 		io.WriteString(w, fmt.Sprintf("task_count=%d\n", len(alltasks)))
-		for _, taskid := range alltasks {
-			if task, state := reg.Get(taskid); state == StateUnknown {
-				log.V(2).Infof("unknown task id: %v", taskid)
-				continue
-			} else if err := func() (err error) {
-				l.Lock()
-				defer l.Unlock()
-
-				podName := task.pod.Name
-				podNamespace := task.pod.Namespace
+		for _, task := range alltasks {
+			if err := func() (err error) {
+				podName := task.Pod.Name
+				podNamespace := task.Pod.Namespace
 				offerId := ""
 				if task.Offer != nil {
 					offerId = task.Offer.Id()
 				}
-				_, err = io.WriteString(w, fmt.Sprintf("%v\t%v/%v\t%v\t%v\n", task.ID, podNamespace, podName, state, offerId))
+				_, err = io.WriteString(w, fmt.Sprintf("%v\t%v/%v\t%v\t%v\n", task.ID, podNamespace, podName, task.State, offerId))
 				return
 			}(); err != nil {
 				log.Warningf("aborting debug handler: %v", err)

--- a/pkg/scheduler/podtask/debug.go
+++ b/pkg/scheduler/podtask/debug.go
@@ -25,12 +25,8 @@ func InstallDebugHandlers(l sync.Locker, reg Registry) {
 				l.Lock()
 				defer l.Unlock()
 
-				podName := ""
-				podNamespace := ""
-				if task.Pod != nil {
-					podName = task.Pod.Name
-					podNamespace = task.Pod.Namespace
-				}
+				podName := task.pod.Name
+				podNamespace := task.pod.Namespace
 				offerId := ""
 				if task.Offer != nil {
 					offerId = task.Offer.Id()

--- a/pkg/scheduler/podtask/pod_task.go
+++ b/pkg/scheduler/podtask/pod_task.go
@@ -215,7 +215,7 @@ func New(ctx api.Context, id string, pod api.Pod, executor *mesos.ExecutorInfo) 
 		return nil, err
 	}
 	if id == "" {
-		id = "pod_" + uuid.NewUUID().String()
+		id = "pod." + uuid.NewUUID().String()
 	}
 	task := &T{
 		ID:       id,

--- a/pkg/scheduler/podtask/pod_task_test.go
+++ b/pkg/scheduler/podtask/pod_task_test.go
@@ -67,7 +67,7 @@ func TestNoPortsInPodOrOffer(t *testing.T) {
 func TestDefaultHostPortMatching(t *testing.T) {
 	t.Parallel()
 	task, _ := fakePodTask("foo")
-	pod := &task.pod
+	pod := &task.Pod
 
 	offer := &mesos.Offer{
 		Resources: []*mesos.Resource{
@@ -107,7 +107,7 @@ func TestDefaultHostPortMatching(t *testing.T) {
 func TestAcceptOfferPorts(t *testing.T) {
 	t.Parallel()
 	task, _ := fakePodTask("foo")
-	pod := &task.pod
+	pod := &task.Pod
 
 	offer := &mesos.Offer{
 		Resources: []*mesos.Resource{

--- a/pkg/scheduler/podtask/pod_task_test.go
+++ b/pkg/scheduler/podtask/pod_task_test.go
@@ -14,7 +14,7 @@ const (
 )
 
 func fakePodTask(id string) (*T, error) {
-	return New(api.NewDefaultContext(), &api.Pod{
+	return New(api.NewDefaultContext(), "", api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:      id,
 			Namespace: api.NamespaceDefault,
@@ -67,7 +67,7 @@ func TestNoPortsInPodOrOffer(t *testing.T) {
 func TestDefaultHostPortMatching(t *testing.T) {
 	t.Parallel()
 	task, _ := fakePodTask("foo")
-	pod := task.Pod
+	pod := &task.pod
 
 	offer := &mesos.Offer{
 		Resources: []*mesos.Resource{
@@ -92,7 +92,7 @@ func TestDefaultHostPortMatching(t *testing.T) {
 			}},
 		}},
 	}
-	task, err = New(api.NewDefaultContext(), pod, &mesos.ExecutorInfo{})
+	task, err = New(api.NewDefaultContext(), "", *pod, &mesos.ExecutorInfo{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestDefaultHostPortMatching(t *testing.T) {
 func TestAcceptOfferPorts(t *testing.T) {
 	t.Parallel()
 	task, _ := fakePodTask("foo")
-	pod := task.Pod
+	pod := &task.pod
 
 	offer := &mesos.Offer{
 		Resources: []*mesos.Resource{

--- a/pkg/scheduler/podtask/protobuf.go
+++ b/pkg/scheduler/podtask/protobuf.go
@@ -27,9 +27,3 @@ func newRanges(ports []uint64) *mesos.Value_Ranges {
 	}
 	return &mesos.Value_Ranges{Range: r}
 }
-
-func newTaskInfo(name string) *mesos.TaskInfo {
-	return &mesos.TaskInfo{
-		Name: proto.String(name),
-	}
-}

--- a/pkg/scheduler/podtask/registry.go
+++ b/pkg/scheduler/podtask/registry.go
@@ -189,8 +189,8 @@ func fillRunningPodInfo(task *T, taskStatus *mesos.TaskStatus) {
 	if result, err := ParsePodStatusResult(taskStatus); err != nil {
 		log.Errorf("invalid TaskStatus.Data for task '%v': %v", task.ID, err)
 	} else {
-		task.Pod.Status = result.Status
-		log.Infof("received pod status for task %v: %+v", task.ID, task.Pod.Status)
+		task.podStatus = result.Status
+		log.Infof("received pod status for task %v: %+v", task.ID, result.Status)
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mesosphere/kubernetes-mesos/pkg/offers"
 	offerMetrics "github.com/mesosphere/kubernetes-mesos/pkg/offers/metrics"
 	"github.com/mesosphere/kubernetes-mesos/pkg/proc"
+	"github.com/mesosphere/kubernetes-mesos/pkg/runtime"
 	"github.com/mesosphere/kubernetes-mesos/pkg/scheduler/meta"
 	"github.com/mesosphere/kubernetes-mesos/pkg/scheduler/metrics"
 	"github.com/mesosphere/kubernetes-mesos/pkg/scheduler/podtask"
@@ -302,7 +303,7 @@ func (k *KubernetesScheduler) onInitialRegistration(driver bindings.SchedulerDri
 		if k.failoverTimeout < defaultFrameworkIdRefreshInterval {
 			refreshInterval = time.Duration(math.Max(1, k.failoverTimeout/2)) * time.Second
 		}
-		go util.Until(k.storeFrameworkId, refreshInterval, k.terminate)
+		go runtime.Until(k.storeFrameworkId, refreshInterval, k.terminate)
 	}
 
 	r1 := k.makeTaskRegistryReconciler()
@@ -313,7 +314,7 @@ func (k *KubernetesScheduler) onInitialRegistration(driver bindings.SchedulerDri
 
 	if k.reconcileInterval > 0 {
 		ri := time.Duration(k.reconcileInterval) * time.Second
-		time.AfterFunc(initialImplicitReconciliationDelay, func() { go util.Until(k.reconciler.RequestImplicit, ri, k.terminate) })
+		time.AfterFunc(initialImplicitReconciliationDelay, func() { go runtime.Until(k.reconciler.RequestImplicit, ri, k.terminate) })
 		log.Infof("will perform implicit task reconciliation at interval: %v after %v", ri, initialImplicitReconciliationDelay)
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -314,7 +314,7 @@ func (k *KubernetesScheduler) onInitialRegistration(driver bindings.SchedulerDri
 
 	if k.reconcileInterval > 0 {
 		ri := time.Duration(k.reconcileInterval) * time.Second
-		time.AfterFunc(initialImplicitReconciliationDelay, func() { go runtime.Until(k.reconciler.RequestImplicit, ri, k.terminate) })
+		time.AfterFunc(initialImplicitReconciliationDelay, func() { runtime.Until(k.reconciler.RequestImplicit, ri, k.terminate) })
 		log.Infof("will perform implicit task reconciliation at interval: %v after %v", ri, initialImplicitReconciliationDelay)
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -176,11 +176,9 @@ func New(config Config) *KubernetesScheduler {
 	return k
 }
 
-func (k *KubernetesScheduler) Init(driver bindings.SchedulerDriver, electedMaster proc.Process, pl PluginInterface) error {
-	k.Lock()
-	defer k.Unlock()
+func (k *KubernetesScheduler) Init(electedMaster proc.Process, pl PluginInterface) error {
+	log.V(1).Infoln("initializing kubernetes mesos scheduler")
 
-	k.driver = driver
 	//TODO(jdef) watch electedMaster.Done() to figure out when background jobs should be shut down
 	k.asRegisteredMaster = proc.DoerFunc(func(a proc.Action) error {
 		if !k.registered {
@@ -268,6 +266,7 @@ func (k *KubernetesScheduler) InstallDebugHandlers() {
 func (k *KubernetesScheduler) Registered(drv bindings.SchedulerDriver, fid *mesos.FrameworkID, mi *mesos.MasterInfo) {
 	log.Infof("Scheduler registered with the master: %v with frameworkId: %v\n", mi, fid)
 
+	k.driver = drv
 	k.frameworkId = fid
 	k.masterInfo = mi
 	k.registered = true
@@ -288,6 +287,7 @@ func (k *KubernetesScheduler) storeFrameworkId() {
 func (k *KubernetesScheduler) Reregistered(drv bindings.SchedulerDriver, mi *mesos.MasterInfo) {
 	log.Infof("Scheduler reregistered with the master: %v\n", mi)
 
+	k.driver = drv
 	k.masterInfo = mi
 	k.registered = true
 

--- a/pkg/scheduler/service/compat_unix.go
+++ b/pkg/scheduler/service/compat_unix.go
@@ -1,4 +1,5 @@
 // +build darwin dragonfly freebsd linux netbsd openbsd
+// +build !unit_test
 
 package service
 

--- a/pkg/scheduler/service/compat_unix.go
+++ b/pkg/scheduler/service/compat_unix.go
@@ -1,0 +1,21 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package service
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func makeFailoverSigChan() <-chan os.Signal {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGUSR1)
+	return ch
+}
+
+func makeDisownedProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setpgid: true, // disown the spawned scheduler
+	}
+}

--- a/pkg/scheduler/service/compat_windows.go
+++ b/pkg/scheduler/service/compat_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+// +build !unit_test
 
 package service
 

--- a/pkg/scheduler/service/compat_windows.go
+++ b/pkg/scheduler/service/compat_windows.go
@@ -1,0 +1,34 @@
+// +build windows
+
+package service
+
+import (
+	"os"
+	"syscall"
+)
+
+func makeFailoverSigChan() <-chan os.Signal {
+	/* TODO(jdef)
+		from go's windows compatibility test, it looks like we need to provide a filtered
+		signal channel here
+
+	        c := make(chan os.Signal, 10)
+	        signal.Notify(c)
+	        select {
+	        case s := <-c:
+	                if s != os.Interrupt {
+	                        log.Fatalf("Wrong signal received: got %q, want %q\n", s, os.Interrupt)
+	                }
+	        case <-time.After(3 * time.Second):
+	                log.Fatalf("Timeout waiting for Ctrl+Break\n")
+	        }
+	*/
+	return nil
+}
+
+func makeDisownedProcAttr() *syscall.SysProcAttr {
+	//TODO(jdef) test this somehow?!?!
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | syscall.CREATE_UNICODE_ENVIRONMENT,
+	}
+}

--- a/pkg/scheduler/service/service.go
+++ b/pkg/scheduler/service/service.go
@@ -387,13 +387,12 @@ func (s *SchedulerServer) Run(hks *hyperkube.Server, _ []string) error {
 
 	var driver bindings.SchedulerDriver
 	driverFactory := ha.DriverFactory(func() (drv bindings.SchedulerDriver, err error) {
-		if err = deferredInit(); err == nil {
-			// defer obtaining framework ID to prevent multiple schedulers
-			// from overwriting each other's framework IDs
-			if dconfig.Framework.Id, err = s.fetchFrameworkID(etcdClient); err == nil {
-				drv, err = bindings.NewMesosSchedulerDriver(*dconfig)
-				driver = drv
-			}
+		// defer obtaining framework ID to prevent multiple schedulers
+		// from overwriting each other's framework IDs
+		if dconfig.Framework.Id, err = s.fetchFrameworkID(etcdClient); err == nil {
+			drv, err = bindings.NewMesosSchedulerDriver(*dconfig)
+			driver = drv
+			err = deferredInit(drv)
 		}
 		return
 	})
@@ -454,7 +453,7 @@ func validateLeadershipTransition(desired, current string) {
 	}
 }
 
-func (s *SchedulerServer) bootstrap(hks *hyperkube.Server) (*ha.SchedulerProcess, *bindings.DriverConfig, scheduler.PluginInterface, tools.EtcdClient, func() error, uint64) {
+func (s *SchedulerServer) bootstrap(hks *hyperkube.Server) (*ha.SchedulerProcess, *bindings.DriverConfig, scheduler.PluginInterface, tools.EtcdClient, func(bindings.SchedulerDriver) error, uint64) {
 
 	s.FrameworkName = strings.TrimSpace(s.FrameworkName)
 	if s.FrameworkName == "" {
@@ -530,8 +529,8 @@ func (s *SchedulerServer) bootstrap(hks *hyperkube.Server) (*ha.SchedulerProcess
 	}
 
 	kpl := scheduler.NewPlugin(mesosPodScheduler.NewPluginConfig(schedulerProcess.Done()))
-	return schedulerProcess, dconfig, kpl, etcdClient, func() (err error) {
-		if err = mesosPodScheduler.Init(schedulerProcess.Master(), kpl); err != nil {
+	return schedulerProcess, dconfig, kpl, etcdClient, func(d bindings.SchedulerDriver) (err error) {
+		if err = mesosPodScheduler.Init(d, schedulerProcess.Master(), kpl); err != nil {
 			err = fmt.Errorf("failed to initialize pod scheduler: %v", err)
 		}
 		return

--- a/pkg/scheduler/service/service_test.go
+++ b/pkg/scheduler/service/service_test.go
@@ -1,0 +1,103 @@
+// +build unit_test
+
+package service
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/mesosphere/kubernetes-mesos/pkg/runtime"
+)
+
+type fakeSchedulerProcess struct {
+	doneFunc     func() <-chan struct{}
+	failoverFunc func() <-chan struct{}
+	ended        runtime.Latch
+}
+
+func (self *fakeSchedulerProcess) Done() <-chan struct{} {
+	if self == nil || self.doneFunc == nil {
+		return nil
+	}
+	return self.doneFunc()
+}
+
+func (self *fakeSchedulerProcess) Failover() <-chan struct{} {
+	if self == nil || self.failoverFunc == nil {
+		return nil
+	}
+	return self.failoverFunc()
+}
+
+func (self *fakeSchedulerProcess) End() {
+	self.ended.Acquire()
+}
+
+func makeFailoverSigChan() <-chan os.Signal {
+	return nil
+}
+
+func makeDisownedProcAttr() *syscall.SysProcAttr {
+	return nil
+}
+
+func Test_awaitFailoverDone(t *testing.T) {
+	done := make(chan struct{})
+	p := &fakeSchedulerProcess{
+		doneFunc: func() <-chan struct{} { return done },
+	}
+	ss := &SchedulerServer{}
+	failoverHandlerCalled := false
+	failoverFailedHandler := func() error {
+		failoverHandlerCalled = true
+		return nil
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ss.awaitFailover(p, failoverFailedHandler)
+	}()
+	close(done)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for failover")
+	}
+	if failoverHandlerCalled {
+		t.Fatalf("unexpected call to failover handler")
+	}
+}
+
+func Test_awaitFailoverDoneFailover(t *testing.T) {
+	ch := make(chan struct{})
+	p := &fakeSchedulerProcess{
+		doneFunc:     func() <-chan struct{} { return ch },
+		failoverFunc: func() <-chan struct{} { return ch },
+	}
+	ss := &SchedulerServer{}
+	failoverHandlerCalled := false
+	failoverFailedHandler := func() error {
+		failoverHandlerCalled = true
+		return nil
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ss.awaitFailover(p, failoverFailedHandler)
+	}()
+	close(ch)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for failover")
+	}
+	if !failoverHandlerCalled {
+		t.Fatalf("expected call to failover handler")
+	}
+}


### PR DESCRIPTION
First round of changes for constraints support. We want to walk snapshots of the task registry to evaluate pod placement and the older interfaces and implementation left much to be desired, including reliance upon the KubernetesScheduler state to guard against changes to pod tasks managed by the podtask.Registry. Ugh.

Changes here include:
- initial constraints interface, assimilated from Marathon
- refactor scheduler state locking
  - mesos scheduler `KubernetesScheduler` has its own lock (primarily for slave state)
  - plugin scheduler `k8smScheduler` has its own lock (for coordinating scheduler plugin ops)
- refactor `podtask.Registry` API
- panic metrics
- experimental "runtime" package w/ some conveniences
- support for building on windows within cygwin (requires env `CYGWIN=winsymlinks:native`)
- cleanup `proc` interfaces
- resolves #193 (building k8sm on osx/homebrew)
- fix racy failover/process termination

**TODO:**
- [x] investigate multiple data races