### PR TITLE
Upstream cloud provider prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,6 @@ If you are running an older version of etcd you may want to consider an upgrade.
 #### kubernetes-mesos
 
 Ensure that your Mesos cluster is started.
-If you're running a standalone Mesos master on `${servicehost}` then set:
-```shell
-$ export mesos_master=${servicehost}:5050
-```
-
-Or if you have multiple Mesos masters registered with a Zookeeper cluster then set:
-```shell
-$ export mesos_master=zk://${zkserver1}:2181,${zkserver2}:2181,${zkserver3}:2181/mesos
-```
 
 Create a configuration file for the Mesos cloud provider:
 
@@ -105,7 +96,7 @@ The file content should have the following format:
 
 ```ini
 [mesos-cloud]
-	mesos-master        = leader.mesos:5050
+	mesos-master        = host:port
 	http-client-timeout = 5s
 	state-cache-ttl     = 20s
 ```
@@ -125,7 +116,6 @@ Fire up the kubernetes-mesos framework components (yes, these are **all** requir
 ```shell
 $ ./bin/km apiserver \
   --address=${servicehost} \
-  --mesos_master=${mesos_master} \
   --etcd_servers=http://${servicehost}:4001 \
   --portal_net=10.10.10.0/24 \
   --port=8888 \
@@ -134,11 +124,10 @@ $ ./bin/km apiserver \
 
 $ ./bin/km controller-manager \
   --master=$servicehost:8888 \
-  --mesos_master=${mesos_master}
+ --cloud_config=./mesos-cloud.conf
 
 $ ./bin/km scheduler \
   --address=${servicehost} \
-  --mesos_master=${mesos_master} \
   --etcd_servers=http://${servicehost}:4001 \
   --mesos_user=root \
   --api_servers=$servicehost:8888

--- a/README.md
+++ b/README.md
@@ -95,6 +95,31 @@ Or if you have multiple Mesos masters registered with a Zookeeper cluster then s
 $ export mesos_master=zk://${zkserver1}:2181,${zkserver2}:2181,${zkserver3}:2181/mesos
 ```
 
+Create a configuration file for the Mesos cloud provider:
+
+```shell
+$ edit ./mesos-cloud.conf
+```
+
+The file content should have the following format:
+
+```ini
+[mesos-cloud]
+	mesos-master        = leader.mesos:5050
+	http-client-timeout = 5s
+	state-cache-ttl     = 20s
+```
+
+**Mesos Cloud Provider Configuration Options:**
+
+- `mesos-master`: Location of the Mesos master.  This value can take the
+  form `host:port` or a canonical Zookeeper URL
+(`zk://host1:port1,host2:port2/your/znode/path`)
+- `http-client-timeout`: Time to wait for a response from the Mesos
+  master when querying the state.
+- `state-cache-ttl`: Maximum age of the cached Mesos state, after which
+  new values will be fetched.
+
 Fire up the kubernetes-mesos framework components (yes, these are **all** required for a working framework):
 
 ```shell
@@ -105,6 +130,7 @@ $ ./bin/km apiserver \
   --portal_net=10.10.10.0/24 \
   --port=8888 \
   --cloud_provider=mesos
+  --cloud_config=./mesos-cloud.conf
 
 $ ./bin/km controller-manager \
   --master=$servicehost:8888 \

--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@ $ ./bin/km apiserver \
 
 $ ./bin/km controller-manager \
   --master=$servicehost:8888 \
- --cloud_config=./mesos-cloud.conf
+  --cloud_config=./mesos-cloud.conf
 
 $ ./bin/km scheduler \
+  --mesos_master=${mesos_masster} \
   --address=${servicehost} \
   --etcd_servers=http://${servicehost}:4001 \
   --mesos_user=root \

--- a/pkg/cloud/mesos/client.go
+++ b/pkg/cloud/mesos/client.go
@@ -19,8 +19,7 @@ import (
 )
 
 const (
-	mesosHttpClientTimeout = 10 * time.Second //TODO(jdef) configurable via fiag?
-	nodesCacheTTL          = 5 * time.Second  //TODO(jdef) configurable somehow?
+	defaultClusterName = "mesos"
 )
 
 var (
@@ -30,10 +29,10 @@ var (
 type mesosClient struct {
 	masterLock    sync.RWMutex
 	master        string // host:port formatted address
-	client        *http.Client
+	httpClient    *http.Client
 	tr            *http.Transport
 	initialMaster <-chan struct{} // signal chan, closes once an initial, non-nil master is found
-	nodes         *nodesCache
+	state         *stateCache
 }
 
 type slaveNode struct {
@@ -41,44 +40,80 @@ type slaveNode struct {
 	resources *api.NodeResources
 }
 
-type nodesCache struct {
-	sync.Mutex
-	expiresAt time.Time
-	cached    []*slaveNode
-	err       error
-	ttl       time.Duration
-	refill    func(context.Context) ([]*slaveNode, error)
+type mesosState struct {
+	clusterName string
+	nodes       []*slaveNode
 }
 
-// return the cached list of slave nodes. if needed, the cache is refreshed prior to returning the results.
-func (c *nodesCache) get(ctx context.Context) ([]*slaveNode, error) {
+type stateCache struct {
+	sync.Mutex
+	expiresAt time.Time
+	cached    *mesosState
+	err       error
+	ttl       time.Duration
+	refill    func(context.Context) (*mesosState, error)
+}
+
+// Reload the state cache if it has expired.
+func (c *stateCache) reloadCache(ctx context.Context) {
 	now := time.Now()
 	c.Lock()
 	defer c.Unlock()
 	if c.expiresAt.Before(now) {
+		log.V(4).Infof("Reloading cached Mesos state")
 		c.cached, c.err = c.refill(ctx)
 		c.expiresAt = now.Add(c.ttl)
 	} else {
-		log.V(4).Infof("returning cached slave list")
+		log.V(4).Infof("Using cached Mesos state")
 	}
+}
+
+// Returns the cached Mesos state.
+func (c *stateCache) getCachedState(ctx context.Context) (*mesosState, error) {
+	c.reloadCache(ctx)
 	return c.cached, c.err
 }
 
-func newMesosClient(md detector.Master) (*mesosClient, error) {
+// Returns the cached Mesos cluster name.
+func (c *stateCache) getClusterName(ctx context.Context) (string, error) {
+	cached, err := c.getCachedState(ctx)
+	return cached.clusterName, err
+}
+
+// Returns the cached list of slave nodes.
+func (c *stateCache) getNodes(ctx context.Context) ([]*slaveNode, error) {
+	cached, err := c.getCachedState(ctx)
+	return cached.nodes, err
+}
+
+func newMesosClient(
+	md detector.Master,
+	mesosHttpClientTimeout, stateCacheTTL time.Duration) (*mesosClient, error) {
+
 	tr := &http.Transport{}
+	httpClient := &http.Client{
+		Transport: tr,
+		Timeout:   mesosHttpClientTimeout,
+	}
+	return createMesosClient(md, httpClient, tr, stateCacheTTL)
+}
+
+func createMesosClient(
+	md detector.Master,
+	httpClient *http.Client,
+	tr *http.Transport,
+	stateCacheTTL time.Duration) (*mesosClient, error) {
+
 	initialMaster := make(chan struct{})
 	client := &mesosClient{
-		client: &http.Client{
-			Transport: tr,
-			Timeout:   mesosHttpClientTimeout,
-		},
+		httpClient:    httpClient,
 		tr:            tr,
 		initialMaster: initialMaster,
-		nodes: &nodesCache{
-			ttl: nodesCacheTTL,
+		state: &stateCache{
+			ttl: stateCacheTTL,
 		},
 	}
-	client.nodes.refill = client.pollMasterForSlaves
+	client.state.refill = client.pollMasterForState
 	first := true
 	if err := md.Detect(detector.OnMasterChanged(func(info *mesos.MasterInfo) {
 		client.masterLock.Lock()
@@ -109,13 +144,19 @@ func newMesosClient(md detector.Master) (*mesosClient, error) {
 	return client, nil
 }
 
-// return a (possibly) cached list of slaves nodes. it's expected the callers will not modify the contents of the returned slice.
+// Return a (possibly cached) list of slave nodes.
+// Callers must not mutate the contents of the returned slice.
 func (c *mesosClient) listSlaves(ctx context.Context) ([]*slaveNode, error) {
-	return c.nodes.get(ctx)
+	return c.state.getNodes(ctx)
+}
+
+// Return a (possibly cached) cluster name.
+func (c *mesosClient) clusterName(ctx context.Context) (string, error) {
+	return c.state.getClusterName(ctx)
 }
 
 // return an array of slave nodes
-func (c *mesosClient) pollMasterForSlaves(ctx context.Context) ([]*slaveNode, error) {
+func (c *mesosClient) pollMasterForState(ctx context.Context) (*mesosState, error) {
 	// wait for initial master detection
 	select {
 	case <-c.initialMaster: // noop
@@ -139,7 +180,7 @@ func (c *mesosClient) pollMasterForSlaves(ctx context.Context) ([]*slaveNode, er
 	if err != nil {
 		return nil, err
 	}
-	var nodes []*slaveNode
+	var state *mesosState
 	err = c.httpDo(ctx, req, func(res *http.Response, err error) error {
 		if err != nil {
 			return err
@@ -153,22 +194,23 @@ func (c *mesosClient) pollMasterForSlaves(ctx context.Context) ([]*slaveNode, er
 			return err1
 		}
 		log.V(3).Infof("Got mesos state, content length %v", len(blob))
-		nodes, err1 = parseSlaveNodes(blob)
+		state, err1 = parseMesosState(blob)
 		return err1
 	})
-	return nodes, err
+	return state, err
 }
 
-func parseSlaveNodes(blob []byte) ([]*slaveNode, error) {
+func parseMesosState(blob []byte) (*mesosState, error) {
 	type State struct {
-		Slaves []*struct {
+		ClusterName string `json:"cluster"`
+		Slaves      []*struct {
 			Id        string                 `json:"id"`        // ex: 20150106-162714-3815890698-5050-2453-S2
 			Pid       string                 `json:"pid"`       // ex: slave(1)@10.22.211.18:5051
 			Hostname  string                 `json:"hostname"`  // ex: 10.22.211.18, or slave-123.nowhere.com
 			Resources map[string]interface{} `json:"resources"` // ex: {"mem": 123, "ports": "[31000-3200]"}
 		} `json:"slaves"`
 	}
-	state := &State{}
+	state := &State{ClusterName: defaultClusterName}
 	if err := json.Unmarshal(blob, state); err != nil {
 		return nil, err
 	}
@@ -208,7 +250,13 @@ func parseSlaveNodes(blob []byte) ([]*slaveNode, error) {
 		}
 		nodes = append(nodes, node)
 	}
-	return nodes, nil
+
+	result := &mesosState{
+		clusterName: state.ClusterName,
+		nodes:       nodes,
+	}
+
+	return result, nil
 }
 
 type responseHandler func(*http.Response, error) error
@@ -217,7 +265,7 @@ type responseHandler func(*http.Response, error) error
 func (c *mesosClient) httpDo(ctx context.Context, req *http.Request, f responseHandler) error {
 	// Run the HTTP request in a goroutine and pass the response to f.
 	ch := make(chan error, 1)
-	go func() { ch <- f(c.client.Do(req)) }()
+	go func() { ch <- f(c.httpClient.Do(req)) }()
 	select {
 	case <-ctx.Done():
 		c.tr.CancelRequest(req)

--- a/pkg/cloud/mesos/client.go
+++ b/pkg/cloud/mesos/client.go
@@ -123,11 +123,7 @@ func createMesosClient(
 		} else if host := info.GetHostname(); host != "" {
 			client.master = host
 		} else {
-			// unpack IPv4
-			octets := make([]byte, 4, 4)
-			binary.BigEndian.PutUint32(octets, info.GetIp())
-			ipv4 := net.IP(octets)
-			client.master = ipv4.String()
+			client.master = unpackIPv4(info.GetIp())
 		}
 		if len(client.master) > 0 {
 			client.master = fmt.Sprintf("%s:%d", client.master, info.GetPort())
@@ -142,6 +138,13 @@ func createMesosClient(
 		return nil, err
 	}
 	return client, nil
+}
+
+func unpackIPv4(ip uint32) string {
+	octets := make([]byte, 4, 4)
+	binary.BigEndian.PutUint32(octets, ip)
+	ipv4 := net.IP(octets)
+	return ipv4.String()
 }
 
 // Return a (possibly cached) list of slave nodes.

--- a/pkg/cloud/mesos/client_test.go
+++ b/pkg/cloud/mesos/client_test.go
@@ -18,11 +18,11 @@ import (
 // Test data
 
 const (
-	masterId   = "master-12345"
-	masterIp   = 177048842
-	masterPort = 5050
+	TEST_MASTER_ID   = "master-12345"
+	TEST_MASTER_IP   = 177048842 // 10.141.141.10
+	TEST_MASTER_PORT = 5050
 
-	stateJson = `
+	TEST_STATE_JSON = `
 	{
 		"version": "0.22.0",
 		"unregistered_frameworks": [],
@@ -139,7 +139,7 @@ func (md FakeMasterDetector) Cancel() {
 
 func (md FakeMasterDetector) Detect(cb detector.MasterChanged) error {
 	md.callback = cb
-	leadingMaster := mesosutil.NewMasterInfo(masterId, masterIp, masterPort)
+	leadingMaster := mesosutil.NewMasterInfo(TEST_MASTER_ID, TEST_MASTER_IP, TEST_MASTER_PORT)
 	cb.OnMasterChanged(leadingMaster)
 	return nil
 }
@@ -156,7 +156,7 @@ func makeHttpMocks() (*httptest.Server, *http.Client, *http.Transport) {
 		if r.URL.Path == "/state.json" {
 			w.WriteHeader(200) // OK
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintln(w, stateJson)
+			fmt.Fprintln(w, TEST_STATE_JSON)
 		} else {
 			w.WriteHeader(400)
 			fmt.Fprintln(w, "Bad Request")
@@ -179,7 +179,7 @@ func makeHttpMocks() (*httptest.Server, *http.Client, *http.Transport) {
 
 // test mesos.parseMesosState
 func Test_parseMesosState(t *testing.T) {
-	state, err := parseMesosState([]byte(stateJson))
+	state, err := parseMesosState([]byte(TEST_STATE_JSON))
 
 	if err != nil {
 		t.Fatalf("parseMesosState does not yield an error")
@@ -198,7 +198,7 @@ func Test_listSlaves(t *testing.T) {
 	md := FakeMasterDetector{}
 	httpServer, httpClient, httpTransport := makeHttpMocks()
 	defer httpServer.Close()
-	cacheTTL, _ := time.ParseDuration("500ms")
+	cacheTTL := 500 * time.Millisecond
 	mesosClient, err := createMesosClient(md, httpClient, httpTransport, cacheTTL)
 
 	if err != nil {
@@ -236,7 +236,7 @@ func Test_clusterName(t *testing.T) {
 	md := FakeMasterDetector{}
 	httpServer, httpClient, httpTransport := makeHttpMocks()
 	defer httpServer.Close()
-	cacheTTL, _ := time.ParseDuration("500ms")
+	cacheTTL := 500 * time.Millisecond
 	mesosClient, err := createMesosClient(md, httpClient, httpTransport, cacheTTL)
 
 	name, err := mesosClient.clusterName(context.TODO())

--- a/pkg/cloud/mesos/client_test.go
+++ b/pkg/cloud/mesos/client_test.go
@@ -1,0 +1,250 @@
+package mesos
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	log "github.com/golang/glog"
+	"github.com/mesos/mesos-go/detector"
+	"github.com/mesos/mesos-go/mesosutil"
+	"golang.org/x/net/context"
+)
+
+// Test data
+
+const (
+	masterId   = "master-12345"
+	masterIp   = 177048842
+	masterPort = 5050
+
+	stateJson = `
+	{
+		"version": "0.22.0",
+		"unregistered_frameworks": [],
+		"started_tasks": 0,
+		"start_time": 1429456501.61141,
+		"staged_tasks": 0,
+		"slaves": [
+		{
+			"resources": {
+				"ports": "[31000-32000]",
+				"mem": 15360,
+				"disk": 470842,
+				"cpus": 8
+			},
+			"registered_time": 1429456502.46999,
+			"pid": "slave(1)@mesos1.internal.company.com:5050",
+			"id": "20150419-081501-16777343-5050-16383-S2",
+			"hostname": "mesos1.internal.company.com",
+			"attributes": {},
+			"active": true
+		},
+		{
+			"resources": {
+				"ports": "[31000-32000]",
+				"mem": 15360,
+				"disk": 470842,
+				"cpus": 8
+			},
+			"registered_time": 1429456502.4144,
+			"pid": "slave(1)@mesos2.internal.company.com:5050",
+			"id": "20150419-081501-16777343-5050-16383-S1",
+			"hostname": "mesos2.internal.company.com",
+			"attributes": {},
+			"active": true
+		},
+		{
+			"resources": {
+				"ports": "[31000-32000]",
+				"mem": 15360,
+				"disk": 470842,
+				"cpus": 8
+			},
+			"registered_time": 1429456502.02879,
+			"pid": "slave(1)@mesos3.internal.company.com:5050",
+			"id": "20150419-081501-16777343-5050-16383-S0",
+			"hostname": "mesos3.internal.company.com",
+			"attributes": {},
+			"active": true
+		}
+		],
+		"pid": "master@mesos-master0.internal.company.com:5050",
+		"orphan_tasks": [],
+		"lost_tasks": 0,
+		"leader": "master@mesos-master0.internal.company.com:5050",
+		"killed_tasks": 0,
+		"failed_tasks": 0,
+		"elected_time": 1429456501.61638,
+		"deactivated_slaves": 0,
+		"completed_frameworks": [],
+		"build_user": "buildbot",
+		"build_time": 1425085311,
+		"build_date": "2015-02-27 17:01:51",
+		"activated_slaves": 3,
+		"finished_tasks": 0,
+		"flags": {
+			"zk_session_timeout": "10secs",
+			"work_dir": "/tmp/mesos/local/Lc9arz",
+			"webui_dir": "/usr/local/share/mesos/webui",
+			"version": "false",
+			"user_sorter": "drf",
+			"slave_reregister_timeout": "10mins",
+			"logbufsecs": "0",
+			"log_auto_initialize": "true",
+			"initialize_driver_logging": "true",
+			"framework_sorter": "drf",
+			"authenticators": "crammd5",
+			"authenticate_slaves": "false",
+			"authenticate": "false",
+			"allocation_interval": "1secs",
+			"logging_level": "INFO",
+			"quiet": "false",
+			"recovery_slave_removal_limit": "100%",
+			"registry": "replicated_log",
+			"registry_fetch_timeout": "1mins",
+			"registry_store_timeout": "5secs",
+			"registry_strict": "false",
+			"root_submissions": "true"
+		},
+		"frameworks": [],
+		"git_branch": "refs/heads/0.22.0-rc1",
+		"git_sha": "46834faca67f877631e1beb7d61be5c080ec3dc2",
+		"git_tag": "0.22.0-rc1",
+		"hostname": "localhost",
+		"id": "20150419-081501-16777343-5050-16383"
+	}`
+)
+
+// Mocks
+
+type FakeMasterDetector struct {
+	callback detector.MasterChanged
+	done     chan struct{}
+}
+
+func newFakeMasterDetector() *FakeMasterDetector {
+	return &FakeMasterDetector{
+		done: make(chan struct{}),
+	}
+}
+
+func (md FakeMasterDetector) Cancel() {
+	close(md.done)
+}
+
+func (md FakeMasterDetector) Detect(cb detector.MasterChanged) error {
+	md.callback = cb
+	leadingMaster := mesosutil.NewMasterInfo(masterId, masterIp, masterPort)
+	cb.OnMasterChanged(leadingMaster)
+	return nil
+}
+
+func (md FakeMasterDetector) Done() <-chan struct{} {
+	return md.done
+}
+
+// Auxilliary functions
+
+func makeHttpMocks() (*httptest.Server, *http.Client, *http.Transport) {
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.V(4).Infof("Mocking response for HTTP request: %#v", r)
+		if r.URL.Path == "/state.json" {
+			w.WriteHeader(200) // OK
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, stateJson)
+		} else {
+			w.WriteHeader(400)
+			fmt.Fprintln(w, "Bad Request")
+		}
+	}))
+
+	// Intercept all client requests and feed them to the test server
+	transport := &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return url.Parse(httpServer.URL)
+		},
+	}
+
+	httpClient := &http.Client{Transport: transport}
+
+	return httpServer, httpClient, transport
+}
+
+// Tests
+
+// test mesos.parseMesosState
+func Test_parseMesosState(t *testing.T) {
+	state, err := parseMesosState([]byte(stateJson))
+
+	if err != nil {
+		t.Fatalf("parseMesosState does not yield an error")
+	}
+	if state == nil {
+		t.Fatalf("parseMesosState yields a non-nil state")
+	}
+	if len(state.nodes) != 3 {
+		t.Fatalf("parseMesosState yields a state with 3 nodes")
+	}
+}
+
+// test mesos.listSlaves
+func Test_listSlaves(t *testing.T) {
+	defer log.Flush()
+	md := FakeMasterDetector{}
+	httpServer, httpClient, httpTransport := makeHttpMocks()
+	defer httpServer.Close()
+	cacheTTL, _ := time.ParseDuration("500ms")
+	mesosClient, err := createMesosClient(md, httpClient, httpTransport, cacheTTL)
+
+	if err != nil {
+		t.Fatalf("createMesosClient does not yield an error")
+	}
+
+	slaveNodes, err := mesosClient.listSlaves(context.TODO())
+
+	if err != nil {
+		t.Fatalf("listSlaves does not yield an error")
+	}
+	if len(slaveNodes) != 3 {
+		t.Fatalf("listSlaves yields a collection of size 3")
+	}
+
+	expectedHostnames := map[string]struct{}{
+		"mesos1.internal.company.com": struct{}{},
+		"mesos2.internal.company.com": struct{}{},
+		"mesos3.internal.company.com": struct{}{},
+	}
+
+	actualHostnames := make(map[string]struct{})
+	for _, node := range slaveNodes {
+		actualHostnames[node.hostname] = struct{}{}
+	}
+
+	if !reflect.DeepEqual(expectedHostnames, actualHostnames) {
+		t.Fatalf("listSlaves yields a collection with the expected hostnames")
+	}
+}
+
+// test mesos.clusterName
+func Test_clusterName(t *testing.T) {
+	defer log.Flush()
+	md := FakeMasterDetector{}
+	httpServer, httpClient, httpTransport := makeHttpMocks()
+	defer httpServer.Close()
+	cacheTTL, _ := time.ParseDuration("500ms")
+	mesosClient, err := createMesosClient(md, httpClient, httpTransport, cacheTTL)
+
+	name, err := mesosClient.clusterName(context.TODO())
+
+	if err != nil {
+		t.Fatalf("clusterName does not yield an error")
+	}
+	if name != defaultClusterName {
+		t.Fatalf("clusterName yields the expected (default) value")
+	}
+}

--- a/pkg/cloud/mesos/config.go
+++ b/pkg/cloud/mesos/config.go
@@ -1,0 +1,79 @@
+package mesos
+
+import (
+	"io"
+	"time"
+
+	"code.google.com/p/gcfg"
+)
+
+const (
+	DefaultMesosMaster       = "localhost:5050"
+	DefaultHttpClientTimeout = time.Duration(10) * time.Second
+	DefaultStateCacheTTL     = time.Duration(5) * time.Second
+)
+
+var (
+	config *Config
+)
+
+func getConfig() *Config {
+	return config
+}
+
+func resetConfigToDefault() {
+	config = createDefaultConfig()
+}
+
+func init() {
+	resetConfigToDefault()
+}
+
+// Example Mesos cloud provider configuration file:
+//
+// [mesos-cloud]
+//  mesos-master        = leader.mesos:5050
+//	http-client-timeout = 500ms
+//	state-cache-ttl     = 1h
+
+type ConfigWrapper struct {
+	Mesos_Cloud Config
+}
+
+type Config struct {
+	MesosMaster            string          `gcfg:"mesos-master"`
+	MesosHttpClientTimeout WrappedDuration `gcfg:"http-client-timeout"`
+	StateCacheTTL          WrappedDuration `gcfg:"state-cache-ttl"`
+}
+
+type WrappedDuration struct {
+	Duration time.Duration `gcfg:"duration"`
+}
+
+func (wd *WrappedDuration) UnmarshalText(data []byte) error {
+	d, err := time.ParseDuration(string(data))
+	if err == nil {
+		wd.Duration = d
+	}
+	return err
+}
+
+func createDefaultConfig() *Config {
+	return &Config{
+		MesosMaster:            DefaultMesosMaster,
+		MesosHttpClientTimeout: WrappedDuration{Duration: DefaultHttpClientTimeout},
+		StateCacheTTL:          WrappedDuration{Duration: DefaultStateCacheTTL},
+	}
+}
+
+func readConfig(configReader io.Reader) error {
+	resetConfigToDefault()
+	wrapper := &ConfigWrapper{Mesos_Cloud: *config}
+	if configReader != nil {
+		if err := gcfg.ReadInto(wrapper, configReader); err != nil {
+			return err
+		}
+		config = &(wrapper.Mesos_Cloud)
+	}
+	return nil
+}

--- a/pkg/cloud/mesos/config_test.go
+++ b/pkg/cloud/mesos/config_test.go
@@ -14,15 +14,15 @@ func Test_createDefaultConfig(t *testing.T) {
 
 	config := createDefaultConfig()
 
-	if config.MesosMaster != "localhost:5050" {
+	if config.MesosMaster != DefaultMesosMaster {
 		t.Fatalf("Default config has the expected MesosMaster value")
 	}
 
-	if config.MesosHttpClientTimeout.Duration != time.Duration(10)*time.Second {
+	if config.MesosHttpClientTimeout.Duration != DefaultHttpClientTimeout {
 		t.Fatalf("Default config has the expected MesosHttpClientTimeout value")
 	}
 
-	if config.StateCacheTTL.Duration != time.Duration(5)*time.Second {
+	if config.StateCacheTTL.Duration != DefaultStateCacheTTL {
 		t.Fatalf("Default config has the expected StateCacheTTL value")
 	}
 }
@@ -39,21 +39,21 @@ func Test_readConfig(t *testing.T) {
 
 	reader := bytes.NewBufferString(configString)
 
-	err := readConfig(reader)
+	config, err := readConfig(reader)
 
 	if err != nil {
 		t.Fatalf("Reading configuration does not yield an error: %#v", err)
 	}
 
-	if getConfig().MesosMaster != "leader.mesos:5050" {
+	if config.MesosMaster != "leader.mesos:5050" {
 		t.Fatalf("Parsed config has the expected MesosMaster value")
 	}
 
-	if getConfig().MesosHttpClientTimeout.Duration != time.Duration(500)*time.Millisecond {
+	if config.MesosHttpClientTimeout.Duration != time.Duration(500)*time.Millisecond {
 		t.Fatalf("Parsed config has the expected MesosHttpClientTimeout value")
 	}
 
-	if getConfig().StateCacheTTL.Duration != time.Duration(1)*time.Hour {
+	if config.StateCacheTTL.Duration != time.Duration(1)*time.Hour {
 		t.Fatalf("Parsed config has the expected StateCacheTTL value")
 	}
 }

--- a/pkg/cloud/mesos/config_test.go
+++ b/pkg/cloud/mesos/config_test.go
@@ -1,0 +1,59 @@
+package mesos
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	log "github.com/golang/glog"
+)
+
+// test mesos.createDefaultConfig
+func Test_createDefaultConfig(t *testing.T) {
+	defer log.Flush()
+
+	config := createDefaultConfig()
+
+	if config.MesosMaster != "localhost:5050" {
+		t.Fatalf("Default config has the expected MesosMaster value")
+	}
+
+	if config.MesosHttpClientTimeout.Duration != time.Duration(10)*time.Second {
+		t.Fatalf("Default config has the expected MesosHttpClientTimeout value")
+	}
+
+	if config.StateCacheTTL.Duration != time.Duration(5)*time.Second {
+		t.Fatalf("Default config has the expected StateCacheTTL value")
+	}
+}
+
+// test mesos.readConfig
+func Test_readConfig(t *testing.T) {
+	defer log.Flush()
+
+	configString := `
+[mesos-cloud]
+	mesos-master        = leader.mesos:5050
+	http-client-timeout = 500ms
+	state-cache-ttl     = 1h`
+
+	reader := bytes.NewBufferString(configString)
+
+	err := readConfig(reader)
+
+	if err != nil {
+		t.Fatalf("Reading configuration does not yield an error: %#v", err)
+	}
+
+	if getConfig().MesosMaster != "leader.mesos:5050" {
+		t.Fatalf("Parsed config has the expected MesosMaster value")
+	}
+
+	if getConfig().MesosHttpClientTimeout.Duration != time.Duration(500)*time.Millisecond {
+		t.Fatalf("Parsed config has the expected MesosHttpClientTimeout value")
+	}
+
+	if getConfig().StateCacheTTL.Duration != time.Duration(1)*time.Hour {
+		t.Fatalf("Parsed config has the expected StateCacheTTL value")
+	}
+}

--- a/pkg/cloud/mesos/mesos_test.go
+++ b/pkg/cloud/mesos/mesos_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"speter.net/go/exp/math/dec/inf"
 )
 
 func TestIPAddress(t *testing.T) {
@@ -50,20 +51,17 @@ func TestIPAddress(t *testing.T) {
 // test mesos.newMesosCloud with no config
 func Test_newMesosCloud_NoConfig(t *testing.T) {
 	defer log.Flush()
-
-	resetConfigToDefault()
-
 	mesosCloud, err := newMesosCloud(nil)
 
 	if err != nil {
 		t.Fatalf("Creating a new Mesos cloud provider without config does not yield an error: %#v", err)
 	}
 
-	if mesosCloud.client.httpClient.Timeout != time.Duration(10)*time.Second {
+	if mesosCloud.client.httpClient.Timeout != DefaultHttpClientTimeout {
 		t.Fatalf("Creating a new Mesos cloud provider without config does not yield an error: %#v", err)
 	}
 
-	if mesosCloud.client.state.ttl != time.Duration(5)*time.Second {
+	if mesosCloud.client.state.ttl != DefaultStateCacheTTL {
 		t.Fatalf("Mesos client with default config has the expected state cache TTL value")
 	}
 }
@@ -71,8 +69,6 @@ func Test_newMesosCloud_NoConfig(t *testing.T) {
 // test mesos.newMesosCloud with custom config
 func Test_newMesosCloud_WithConfig(t *testing.T) {
 	defer log.Flush()
-
-	resetConfigToDefault()
 
 	configString := `
 [mesos-cloud]
@@ -94,4 +90,183 @@ func Test_newMesosCloud_WithConfig(t *testing.T) {
 	if mesosCloud.client.state.ttl != time.Duration(1)*time.Hour {
 		t.Fatalf("Mesos client with a custom config has the expected state cache TTL value")
 	}
+}
+
+// tests for capability reporting functions
+
+// test mesos.Instances
+func Test_Instances(t *testing.T) {
+	defer log.Flush()
+	mesosCloud, _ := newMesosCloud(nil)
+
+	instances, supports_instances := mesosCloud.Instances()
+
+	if !supports_instances || instances == nil {
+		t.Fatalf("MesosCloud provides an implementation of Instances")
+	}
+}
+
+// test mesos.TCPLoadBalancer
+func Test_TcpLoadBalancer(t *testing.T) {
+	defer log.Flush()
+	mesosCloud, _ := newMesosCloud(nil)
+
+	lb, supports_lb := mesosCloud.TCPLoadBalancer()
+
+	if supports_lb || lb != nil {
+		t.Fatalf("MesosCloud does not provide an implementation of TCPLoadBalancer")
+	}
+}
+
+// test mesos.Zones
+func Test_Zones(t *testing.T) {
+	defer log.Flush()
+	mesosCloud, _ := newMesosCloud(nil)
+
+	zones, supports_zones := mesosCloud.Zones()
+
+	if supports_zones || zones != nil {
+		t.Fatalf("MesosCloud does not provide an implementation of Zones")
+	}
+}
+
+// test mesos.Clusters
+func Test_Clusters(t *testing.T) {
+	defer log.Flush()
+	mesosCloud, _ := newMesosCloud(nil)
+
+	clusters, supports_clusters := mesosCloud.Clusters()
+
+	if !supports_clusters || clusters == nil {
+		t.Fatalf("MesosCloud does not provide an implementation of Clusters")
+	}
+}
+
+// test mesos.MasterURI
+func Test_MasterURI(t *testing.T) {
+	defer log.Flush()
+	mesosCloud, _ := newMesosCloud(nil)
+
+	uri := mesosCloud.MasterURI()
+
+	if uri != DefaultMesosMaster {
+		t.Fatalf("MasterURI returns the expected master URI (expected \"localhost\", actual \"%s\"", uri)
+	}
+}
+
+// test mesos.ListClusters
+func Test_ListClusters(t *testing.T) {
+	defer log.Flush()
+	md := FakeMasterDetector{}
+	httpServer, httpClient, httpTransport := makeHttpMocks()
+	defer httpServer.Close()
+	cacheTTL := 500 * time.Millisecond
+	mesosClient, err := createMesosClient(md, httpClient, httpTransport, cacheTTL)
+	mesosCloud := &MesosCloud{client: mesosClient, config: createDefaultConfig()}
+
+	clusters, err := mesosCloud.ListClusters()
+
+	if err != nil {
+		t.Fatalf("ListClusters does not yield an error: %#v", err)
+	}
+
+	if len(clusters) != 1 {
+		t.Fatalf("ListClusters should return a list of size 1: (actual: %#v)", clusters)
+	}
+
+	expectedClusterNames := []string{"mesos"}
+
+	if !reflect.DeepEqual(clusters, expectedClusterNames) {
+		t.Fatalf("ListClusters should return the expected list of names: (expected: %#v, actual: %#v)",
+			expectedClusterNames,
+			clusters)
+	}
+}
+
+// test mesos.Master
+func Test_Master(t *testing.T) {
+	defer log.Flush()
+	md := FakeMasterDetector{}
+	httpServer, httpClient, httpTransport := makeHttpMocks()
+	defer httpServer.Close()
+	cacheTTL := 500 * time.Millisecond
+	mesosClient, err := createMesosClient(md, httpClient, httpTransport, cacheTTL)
+	mesosCloud := &MesosCloud{client: mesosClient, config: createDefaultConfig()}
+
+	clusters, err := mesosCloud.ListClusters()
+	clusterName := clusters[0]
+	master, err := mesosCloud.Master(clusterName)
+
+	if err != nil {
+		t.Fatalf("Master does not yield an error: %#v", err)
+	}
+
+	expectedMaster := unpackIPv4(TEST_MASTER_IP)
+
+	if master != expectedMaster {
+		t.Fatalf("Master returns the expected value: (expected: %#v, actual: %#v", expectedMaster, master)
+	}
+}
+
+// test mesos.List
+func Test_List(t *testing.T) {
+	defer log.Flush()
+	md := FakeMasterDetector{}
+	httpServer, httpClient, httpTransport := makeHttpMocks()
+	defer httpServer.Close()
+	cacheTTL := 500 * time.Millisecond
+	mesosClient, err := createMesosClient(md, httpClient, httpTransport, cacheTTL)
+	mesosCloud := &MesosCloud{client: mesosClient, config: createDefaultConfig()}
+
+	clusters, err := mesosCloud.List(".*") // recognizes the language of all strings
+
+	if err != nil {
+		t.Fatalf("List does not yield an error: %#v", err)
+	}
+
+	if len(clusters) != 3 {
+		t.Fatalf("List with a catch-all filter should return a list of size 3: (actual: %#v)", clusters)
+	}
+
+	clusters, err = mesosCloud.List("$^") // end-of-string followed by start-of-string: recognizes the empty language
+
+	if err != nil {
+		t.Fatalf("List does not yield an error: %#v", err)
+	}
+
+	if len(clusters) != 0 {
+		t.Fatalf("List with a reject-all filter should return a list of size 0: (actual: %#v)", clusters)
+	}
+}
+
+// test mesos.GetNodeResources
+func Test_GetNodeResources(t *testing.T) {
+	defer log.Flush()
+	md := FakeMasterDetector{}
+	httpServer, httpClient, httpTransport := makeHttpMocks()
+	defer httpServer.Close()
+	cacheTTL := 500 * time.Millisecond
+	mesosClient, err := createMesosClient(md, httpClient, httpTransport, cacheTTL)
+	mesosCloud := &MesosCloud{client: mesosClient, config: createDefaultConfig()}
+
+	resources, err := mesosCloud.GetNodeResources("mesos1.internal.company.com")
+
+	if err != nil {
+		t.Fatalf("GetNodeResources does not yield an error: %#v", err)
+	}
+
+	expectedCpu := inf.NewDec(8, 0)
+	expectedMem := inf.NewDec(15360, 0)
+
+	actualCpu := resources.Capacity["cpu"].Amount
+	actualMem := resources.Capacity["memory"].Amount
+
+	if actualCpu.Cmp(expectedCpu) != 0 {
+		t.Fatalf("GetNodeResources should return the expected amount of cpu: (expected: %#v, vactual: %#v)", expectedCpu, actualCpu)
+	}
+
+	if actualMem.Cmp(expectedMem) != 0 {
+		t.Fatalf("GetNodeResources should return the expected amount of memory: (expected: %#v, vactual: %#v)", expectedMem, actualMem)
+	}
+
 }

--- a/pkg/cloud/mesos/mesos_test.go
+++ b/pkg/cloud/mesos/mesos_test.go
@@ -1,9 +1,13 @@
 package mesos
 
 import (
+	"bytes"
 	"net"
 	"reflect"
 	"testing"
+	"time"
+
+	log "github.com/golang/glog"
 )
 
 func TestIPAddress(t *testing.T) {
@@ -40,5 +44,54 @@ func TestIPAddress(t *testing.T) {
 	_, err = c.ipAddress("")
 	if err != noHostNameSpecified {
 		t.Fatalf("expected error noHostNameSpecified but got none")
+	}
+}
+
+// test mesos.newMesosCloud with no config
+func Test_newMesosCloud_NoConfig(t *testing.T) {
+	defer log.Flush()
+
+	resetConfigToDefault()
+
+	mesosCloud, err := newMesosCloud(nil)
+
+	if err != nil {
+		t.Fatalf("Creating a new Mesos cloud provider without config does not yield an error: %#v", err)
+	}
+
+	if mesosCloud.client.httpClient.Timeout != time.Duration(10)*time.Second {
+		t.Fatalf("Creating a new Mesos cloud provider without config does not yield an error: %#v", err)
+	}
+
+	if mesosCloud.client.state.ttl != time.Duration(5)*time.Second {
+		t.Fatalf("Mesos client with default config has the expected state cache TTL value")
+	}
+}
+
+// test mesos.newMesosCloud with custom config
+func Test_newMesosCloud_WithConfig(t *testing.T) {
+	defer log.Flush()
+
+	resetConfigToDefault()
+
+	configString := `
+[mesos-cloud]
+	http-client-timeout = 500ms
+	state-cache-ttl = 1h`
+
+	reader := bytes.NewBufferString(configString)
+
+	mesosCloud, err := newMesosCloud(reader)
+
+	if err != nil {
+		t.Fatalf("Creating a new Mesos cloud provider with a custom config does not yield an error: %#v", err)
+	}
+
+	if mesosCloud.client.httpClient.Timeout != time.Duration(500)*time.Millisecond {
+		t.Fatalf("Mesos client with a custom config has the expected HTTP client timeout value")
+	}
+
+	if mesosCloud.client.state.ttl != time.Duration(1)*time.Hour {
+		t.Fatalf("Mesos client with a custom config has the expected state cache TTL value")
 	}
 }


### PR DESCRIPTION
Addresses a pre-requisite for moving the cloud provider implementation upstream: reading config from a file.  Related to #114.

- [X] Switch from `--mesos-master` flag to read this value from a config file
- [x] Test coverage
- [x] Documentation updates