### PR TITLE
runtime API cleanup, etc

### DIFF
--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -234,6 +234,10 @@ func (b *errorOnce) Err() <-chan error {
 	return b.err
 }
 
+func (b *errorOnce) Reportf(msg string, args ...interface{}) {
+	b.Report(fmt.Errorf(msg, args))
+}
+
 func (b *errorOnce) Report(err error) {
 	b.once.Do(func() {
 		select {

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -235,7 +235,7 @@ func (b *errorOnce) Err() <-chan error {
 }
 
 func (b *errorOnce) Reportf(msg string, args ...interface{}) {
-	b.Report(fmt.Errorf(msg, args))
+	b.Report(fmt.Errorf(msg, args...))
 }
 
 func (b *errorOnce) Report(err error) {
@@ -326,6 +326,10 @@ func DoWith(other Process, d Doer) Process {
 		parent:   other,
 		delegate: d,
 	}
+}
+
+func ErrorChanf(msg string, args ...interface{}) <-chan error {
+	return ErrorChan(fmt.Errorf(msg, args...))
 }
 
 func ErrorChan(err error) <-chan error {

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -93,7 +93,7 @@ func (self *procImpl) begin() runtime.Signal {
 	defer log.V(2).Infof("started process %d", self.pid)
 	var entered runtime.Latch
 	// execute actions on the backlog chan
-	return runtime.Go(func() {
+	return runtime.After(func() {
 		runtime.Until(func() {
 			if entered.Acquire() {
 				close(self.running)
@@ -166,7 +166,7 @@ func (self *procImpl) Do(a Action) <-chan error {
 // the signal chan that's returned closes once the error process logic (and handler,
 // if any) has completed.
 func OnError(ch <-chan error, f func(error), abort <-chan struct{}) <-chan struct{} {
-	return runtime.Go(func() {
+	return runtime.After(func() {
 		if ch == nil {
 			return
 		}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -203,7 +203,7 @@ func TestProc_doWithNestedErrorPropagation(t *testing.T) {
 		delegated = true
 		a()
 		errOnce.Reportf("unexpected error in decorator2")
-		return ErrorChan(fmt.Errorf("another unexpected error in decorator2"))
+		return ErrorChanf("another unexpected error in decorator2")
 	}))
 
 	executed := make(chan struct{})
@@ -254,7 +254,7 @@ func runDelegationTest(t *testing.T, p Process, name string, errOnce ErrorOnce) 
 			}
 			y++
 			if y != x {
-				return ErrorChan(fmt.Errorf("out of order delegated execution"))
+				return ErrorChanf("out of order delegated execution")
 			}
 			defer wg.Done()
 			a()

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -23,7 +23,7 @@ func errorAfter(errOnce ErrorOnce, done <-chan struct{}, d time.Duration, msg st
 	select {
 	case <-done:
 	case <-time.After(d):
-		errOnce.Report(fmt.Errorf(msg, args...))
+		errOnce.Reportf(msg, args...)
 	}
 }
 
@@ -202,7 +202,7 @@ func TestProc_doWithNestedErrorPropagation(t *testing.T) {
 	decorated2 := DoWith(decorated, DoerFunc(func(a Action) <-chan error {
 		delegated = true
 		a()
-		errOnce.Report(fmt.Errorf("unexpected error in decorator2"))
+		errOnce.Reportf("unexpected error in decorator2")
 		return ErrorChan(fmt.Errorf("another unexpected error in decorator2"))
 	}))
 
@@ -267,17 +267,17 @@ func runDelegationTest(t *testing.T, p Process, name string, errOnce ErrorOnce) 
 	err := decorated.Do(func() {
 		defer close(executed)
 		if y != DEPTH {
-			errOnce.Report(fmt.Errorf("expected delegated execution"))
+			errOnce.Reportf("expected delegated execution")
 		}
 		t.Logf("executing deferred action: " + name)
 	})
 	if err == nil {
-		errOnce.Report(fmt.Errorf("expected !nil error chan"))
+		errOnce.Reportf("expected !nil error chan")
 	}
 	errOnce.Send(err)
 	errorAfter(errOnce, executed, 1*time.Second, "timed out waiting deferred execution")
 	errorAfter(errOnce, decorated.OnError(err, func(e error) {
-		errOnce.Report(fmt.Errorf("unexpected error: %v", err))
+		errOnce.Reportf("unexpected error: %v", err)
 	}), 1*time.Second, "timed out waiting for doer result")
 }
 

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -40,6 +40,7 @@ type ErrorOnce interface {
 
 	// reports the given error via Err(), but only if no other errors have been reported or forwarded
 	Report(error)
+	Reportf(string, ...interface{})
 
 	// waits for an error on the incoming chan, the result of which is later obtained via Err() (if no
 	// other errors have been reported or forwarded)

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -27,13 +27,17 @@ type Process interface {
 	Context
 	Doer
 
-	// see top level OnError func
+	// see top level OnError func. this implementation will terminate upon the arrival of
+	// an error (and subsequently invoke the error handler, if given) or else the termination
+	// of the process (testable via IsProcessTerminated).
 	OnError(<-chan error, func(error)) <-chan struct{}
 
 	// return a signal chan that will close once the process is ready to run actions
 	Running() <-chan struct{}
 }
 
+// this is an error promise. if we ever start building out support for other promise types it will probably
+// make sense to group them in some sort of "promises" package.
 type ErrorOnce interface {
 	// return a chan that only ever sends one error, either obtained via Report() or Forward()
 	Err() <-chan error

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -15,13 +15,13 @@ type Signal <-chan struct{}
 // two funcs from separate invocations of Closer() (on the same sig chan) will cause a panic if both invoked.
 // for example:
 //     // good
-//     x := runtime.Go(func() { ... })
+//     x := runtime.After(func() { ... })
 //     f := x.Closer()
 //     f()
 //     f()
 //
 //     // bad
-//     x := runtime.Go(func() { ... })
+//     x := runtime.After(func() { ... })
 //     f := x.Closer()
 //     g := x.Closer()
 //     f()
@@ -49,7 +49,7 @@ func On(sig <-chan struct{}, f func()) Signal {
 	if sig == nil {
 		return nil
 	}
-	return Go(func() {
+	return After(func() {
 		<-sig
 		if f != nil {
 			f()
@@ -61,7 +61,7 @@ func OnOSSignal(sig <-chan os.Signal, f func(os.Signal)) Signal {
 	if sig == nil {
 		return nil
 	}
-	return Go(func() {
+	return After(func() {
 		if s, ok := <-sig; ok && f != nil {
 			f(s)
 		}
@@ -70,7 +70,7 @@ func OnOSSignal(sig <-chan os.Signal, f func(os.Signal)) Signal {
 
 // spawn a goroutine to execute a func, immediately returns a chan that closes
 // upon completion of the func. returns a nil signal chan if the given func is nil.
-func Go(f func()) Signal {
+func After(f func()) Signal {
 	ch := make(chan struct{})
 	go func() {
 		defer close(ch)

--- a/pkg/runtime/util_test.go
+++ b/pkg/runtime/util_test.go
@@ -15,7 +15,7 @@ func TestUntil(t *testing.T) {
 	//--
 	ch = make(chan struct{})
 	called := make(chan struct{})
-	Go(func() {
+	After(func() {
 		Until(func() {
 			called <- struct{}{}
 		}, 0, ch)
@@ -29,7 +29,7 @@ func TestUntil(t *testing.T) {
 	ch = make(chan struct{})
 	called = make(chan struct{})
 	running := make(chan struct{})
-	Go(func() {
+	After(func() {
 		Until(func() {
 			close(running)
 			called <- struct{}{}

--- a/pkg/scheduler/ha/ha.go
+++ b/pkg/scheduler/ha/ha.go
@@ -53,7 +53,7 @@ func (stage stageType) Do(p *SchedulerProcess, a proc.Action) <-chan error {
 			case <-p.Done():
 			}
 		case finStage:
-			errOnce.Report(fmt.Errorf("scheduler process is dying, dropping action"))
+			errOnce.Reportf("scheduler process is dying, dropping action")
 		default:
 		}
 		errOnce.Report(stage.When(p, a))

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -165,7 +165,7 @@ func New(config Config) *KubernetesScheduler {
 		reconcileCooldown: config.ReconcileCooldown,
 		registration:      make(chan struct{}),
 		asRegisteredMaster: proc.DoerFunc(func(proc.Action) <-chan error {
-			return proc.ErrorChan(fmt.Errorf("cannot execute action with unregistered scheduler"))
+			return proc.ErrorChanf("cannot execute action with unregistered scheduler")
 		}),
 	}
 	return k
@@ -177,7 +177,7 @@ func (k *KubernetesScheduler) Init(electedMaster proc.Process, pl PluginInterfac
 	//TODO(jdef) watch electedMaster.Done() to figure out when background jobs should be shut down
 	k.asRegisteredMaster = proc.DoerFunc(func(a proc.Action) <-chan error {
 		if !k.registered {
-			return proc.ErrorChan(fmt.Errorf("failed to execute registered action, scheduler is disconnected"))
+			return proc.ErrorChanf("failed to execute registered action, scheduler is disconnected")
 		}
 		return electedMaster.Do(a)
 	})

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -62,7 +62,7 @@ type PluginInterface interface {
 	reconcilePod(api.Pod)
 
 	// execute the Scheduling plugin, should start a go routine and return immediately
-	Run()
+	Run(<-chan struct{})
 }
 
 // KubernetesScheduler implements:


### PR DESCRIPTION
runtime API cleanup, and:
- attempt to fix DATA RACE in pkg/proc unit tests (testing.Fatalf)
- fixed possible multiple registrations for /debug/pprof handler in scheduler service
