### PR TITLE
official dcos packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ install:
   - make
 
 script:
-  - make test.cover
+  - make test.cover test.integration
   - test -n "$COVERALLS_TOKEN" && $(go env GOPATH | awk 'BEGIN{FS=":"} {print $1}')/bin/goveralls -coverprofile=all.coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN || true

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ _GOPATH		:= $(shell uname | grep -e ^CYGWIN >/dev/null && cygpath --mixed "$(BUI
 
 TEST_OBJ	:= $(subst /,___,$(TESTS))
 
-.PHONY: all error require-godep require-vendor install info bootstrap format test patch.v patch version test.v test.vv test.cover clean lint vet fix prepare update $(TEST_OBJ)
+.PHONY: all error require-godep require-vendor install info bootstrap format test patch.v patch version test.v test.vv test.cover clean lint vet fix prepare update $(TEST_OBJ) test.integration
 
 # FRAMEWORK_FLAGS := -v -x -tags '$(TAGS)'
 FRAMEWORK_FLAGS := -tags '$(TAGS)'
@@ -90,7 +90,7 @@ test test.v: patch
 		test -n "$(WITH_RACE)" && args="$$args -race" || true; \
 		env GOPATH=$(_GOPATH) go test $$args -tags unit_test $(TESTS:%=${K8SM_GO_PACKAGE}/%)
 
-test.vv:
+test.vv: patch
 	test -n "$(WITH_RACE)" && args="$$args -race" || args=""; \
 		env GOPATH=$(_GOPATH) go test -test.v $$args -tags unit_test $(TESTS:%=${K8SM_GO_PACKAGE}/%) -logtostderr=true -vmodule=$(TESTS_VV)
 
@@ -100,6 +100,9 @@ test.cover: $(TEST_OBJ)
 $(TEST_OBJ):
 	@test -n "$(WITH_RACE)" && args="$$args -race" || args=""; \
 		env GOPATH=$(_GOPATH) go test -v $$args -covermode=count -coverprofile=.$@.coverage.out -tags unit_test $(K8SM_GO_PACKAGE)/$(subst ___,/,$@)
+
+test.integration:
+	$(current_dir)/hack/test_redirfd.sh
 
 install: all
 	mkdir -p $(DESTDIR)

--- a/cmd/k8sm-redirfd/redirfd.go
+++ b/cmd/k8sm-redirfd/redirfd.go
@@ -1,0 +1,92 @@
+// used for testing the redirfd package. inspired by http://skarnet.org/software/execline/redirfd.html.
+// usage:
+//     k8sm-redirfb [-n] [-b] {mode} {fd} {file} {prog...}
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+
+	"github.com/mesosphere/kubernetes-mesos/pkg/redirfd"
+)
+
+func main() {
+	nonblock := flag.Bool("n", false, "open file in non-blocking mode")
+	changemode := flag.Bool("b", false, "change mode of file after opening it: to non-blocking mode if the -n option was not given, to blocking mode if it was")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 4 {
+		fmt.Fprintf(os.Stderr, "expected {mode} {fd} {file} instead of: %v\n", args)
+		os.Exit(1)
+	}
+
+	var mode redirfd.RedirectMode
+	switch m := args[0]; m {
+	case "r":
+		mode = redirfd.Read
+	case "w":
+		mode = redirfd.Write
+	case "u":
+		mode = redirfd.Update
+	case "a":
+		mode = redirfd.Append
+	case "c":
+		mode = redirfd.AppendExisting
+	case "x":
+		mode = redirfd.WriteNew
+	default:
+		fmt.Fprintf(os.Stderr, "unrecognized mode %q\n", mode)
+		os.Exit(1)
+	}
+
+	fd, err := strconv.Atoi(args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid file descriptor: %q\n", args[1])
+		os.Exit(1)
+	}
+	file := args[2]
+
+	f, err := mode.Redirect(*nonblock, *changemode, fd, file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "redirect failed: %q, %v\n", args[1], err)
+		os.Exit(1)
+	}
+	var pargs []string
+	if len(args) > 4 {
+		pargs = args[4:]
+	}
+	cmd := exec.Command(args[3], pargs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if fd == syscall.Stdin {
+		cmd.Stdin = f
+	} else if fd == syscall.Stdout {
+		cmd.Stdout = f
+	} else if fd == syscall.Stderr {
+		cmd.Stderr = f
+	} else {
+		cmd.ExtraFiles = []*os.File{f}
+	}
+	defer f.Close()
+	if err = cmd.Run(); err != nil {
+		exiterr := err.(*exec.ExitError)
+		state := exiterr.ProcessState
+		if state != nil {
+			sys := state.Sys()
+			if waitStatus, ok := sys.(syscall.WaitStatus); ok {
+				if waitStatus.Signaled() {
+					os.Exit(256 + int(waitStatus.Signal()))
+				} else {
+					os.Exit(waitStatus.ExitStatus())
+				}
+			}
+		}
+		os.Exit(3)
+	}
+}

--- a/examples/guestbook/redis-master.json
+++ b/examples/guestbook/redis-master.json
@@ -8,7 +8,7 @@
       "id": "redis-master-2",
       "containers": [{
         "name": "master",
-        "image": "dockerfile/redis",
+        "image": "library/redis",
         "ports": [{
           "containerPort": 6379,
           "hostPort": 31010 

--- a/examples/guestbook/redis-slave-controller.json
+++ b/examples/guestbook/redis-slave-controller.json
@@ -12,7 +12,7 @@
              "id": "redis-slave-controller",
              "containers": [{
                "name": "slave",
-               "image": "jdef/redis-slave",
+               "image": "mesosphere/kubernetes:guestbook-redis-slave",
                "ports": [{"containerPort": 6379, "hostPort": 31020}]
              }]
            }

--- a/examples/guestbook/redis-slave/Dockerfile
+++ b/examples/guestbook/redis-slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/redis
+FROM library/redis
 
 ADD run.sh /run.sh
 

--- a/examples/pod-nginx.json
+++ b/examples/pod-nginx.json
@@ -7,7 +7,7 @@
       "version": "v1beta1",
       "containers": [{
         "name": "nginx-01",
-        "image": "dockerfile/nginx",
+        "image": "library/nginx",
         "ports": [{
           "containerPort": 80,
           "hostPort": 31000

--- a/hack/deploy/dcos/k8sm-minus-etcd.json
+++ b/hack/deploy/dcos/k8sm-minus-etcd.json
@@ -1,0 +1,34 @@
+{
+  "id": "/k8sm",
+  "cpus": 1,
+  "mem": 1024.0,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "mesosphere/kubernetes:k8s-0.14.2-k8sm-0.5-dcos-dev",
+      "forcePullImage": true
+    }
+  },
+  "env":{
+    "GLOG_v": "1",
+    "DISABLE_ETCD_SERVER": "1",
+    "ETCD_SERVER_LIST": "http://leader.mesos:4001",
+    "APISERVER_PORT": "8888",
+    "APISERVER_RO_PORT": "8889",
+    "SCHEDULER_PORT": "10251",
+    "CONTROLLER_MANAGER_PORT": "10252"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "instances": 1,
+  "healthChecks": [
+    {
+      "command": { "value": "curl -f -XGET http://$HOST:$APISERVER_PORT/healthz" },
+      "intervalSeconds": 90,
+      "maxConsecutiveFailures": 2,
+      "protocol": "COMMAND"
+    }
+  ]
+}

--- a/hack/deploy/dcos/k8sm.json
+++ b/hack/deploy/dcos/k8sm.json
@@ -11,6 +11,8 @@
   },
   "env":{
     "GLOG_v": "1",
+    "ETCD_SERVER_PORT": "4001",
+    "ETCD_SERVER_PEER_PORT": "4002",
     "APISERVER_PORT": "8888",
     "APISERVER_RO_PORT": "8889",
     "SCHEDULER_PORT": "10251",

--- a/hack/deploy/dcos/k8sm.json
+++ b/hack/deploy/dcos/k8sm.json
@@ -2,7 +2,6 @@
   "id": "/k8sm",
   "cpus": 1,
   "mem": 1024.0,
-  "ports": [ 8888, 10251, 10252 ],
   "container": {
     "type": "DOCKER",
     "docker": {
@@ -11,7 +10,11 @@
     }
   },
   "env":{
-    "GLOG_v": "1"
+    "GLOG_v": "1",
+    "APISERVER_PORT": "8888",
+    "APISERVER_RO_PORT": "8889",
+    "SCHEDULER_PORT": "10251",
+    "CONTROLLER_MANAGER_PORT": "10252"
   },
   "upgradeStrategy":{
     "minimumHealthCapacity": 0,
@@ -20,11 +23,10 @@
   "instances": 1,
   "healthChecks": [
     {
+      "command": { "value": "curl -f -XGET http://$HOST:$APISERVER_PORT/healthz" },
       "intervalSeconds": 60,
       "maxConsecutiveFailures": 2,
-      "path": "/healthz",
-      "portIndex": 0,
-      "protocol": "HTTP"
+      "protocol": "COMMAND"
     }
   ]
 }

--- a/hack/deploy/dcos/k8sm.json
+++ b/hack/deploy/dcos/k8sm.json
@@ -5,7 +5,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "jdef/k8sm-km-dcos:0.14.2-0.5-dev",
+      "image": "mesosphere/kubernetes:k8s-0.14.2-k8sm-0.5-dcos-dev",
       "forcePullImage": true
     }
   },
@@ -24,7 +24,7 @@
   "healthChecks": [
     {
       "command": { "value": "curl -f -XGET http://$HOST:$APISERVER_PORT/healthz" },
-      "intervalSeconds": 60,
+      "intervalSeconds": 90,
       "maxConsecutiveFailures": 2,
       "protocol": "COMMAND"
     }

--- a/hack/images/dcos/.gitignore
+++ b/hack/images/dcos/.gitignore
@@ -1,3 +1,4 @@
 usr
 km
 etcd*
+.version

--- a/hack/images/dcos/.gitignore
+++ b/hack/images/dcos/.gitignore
@@ -1,2 +1,3 @@
 usr
 km
+etcd*

--- a/hack/images/dcos/Dockerfile
+++ b/hack/images/dcos/Dockerfile
@@ -9,6 +9,8 @@ ENTRYPOINT [ "/opt/bootstrap.sh" ]
 
 ADD usr			/usr/
 ADD leapsecs.dat	/etc/
+ADD etcd		/opt/
+ADD etcdctl		/opt/
 ADD km			/opt/
 ADD functions.sh	/opt/
 ADD bootstrap.sh	/opt/

--- a/hack/images/dcos/Dockerfile
+++ b/hack/images/dcos/Dockerfile
@@ -4,11 +4,12 @@ MAINTAINER James DeFelice <james.defelice@gmail.com>
 RUN echo 'nobody:x:99:99:Nobody:/:/sbin/false' >>/etc/passwd
 RUN echo 'nobody::99:' >>/etc/group
 
-ADD usr /usr/
-ADD km /km
-ADD leapsecs.dat /etc/
-
 CMD [ ]
-ENTRYPOINT [ "/bootstrap.sh" ]
+ENTRYPOINT [ "/opt/bootstrap.sh" ]
 
-ADD bootstrap.sh /bootstrap.sh
+ADD usr			/usr/
+ADD leapsecs.dat	/etc/
+ADD km			/opt/
+ADD functions.sh	/opt/
+ADD bootstrap.sh	/opt/
+ADD executor.sh		/opt/

--- a/hack/images/dcos/Dockerfile
+++ b/hack/images/dcos/Dockerfile
@@ -15,3 +15,4 @@ ADD km			/opt/
 ADD functions.sh	/opt/
 ADD bootstrap.sh	/opt/
 ADD executor.sh		/opt/
+ADD .version		/opt/

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -33,6 +33,7 @@ deps: $(S6_BINS) $(ETCD_BINS)
 
 build: deps
 	cp -pv $(TARGET) .
+	date -Iseconds >.version
 	$(SUDO) docker build -t $(REPO):$(TAG) .
 
 push:	build

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -15,16 +15,23 @@ EXECLINE_VER ?= 2.1.1.1
 EXECLINE_ARCH ?= $(COMMON_ARCH)
 EXECLINE_OBJ ?= execline-$(EXECLINE_VER)-$(EXECLINE_ARCH)-bin.tar.gz
 
+ETCD_IMAGE = etcd
+ETCD_TAG = 2.0.9
+ETCD_OUTPUT_DIR = $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64
+ETCD_BINS = $(ETCD_OUTPUT_DIR)/etcd $(ETCD_OUTPUT_DIR)/etcdctl
+ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
+
 S6_BINS ?= $(S6_OBJ) $(EXECLINE_OBJ)
 
-.PHONY:	clean build push s6 $(S6_BINS) deps
+.PHONY:	clean build push s6 $(S6_BINS) deps etcd $(ETCD_BINS)
 
+#	rm -rf km $(ETCD_OUTPUT_DIR) usr _build etcd*
 clean:
 	rm -rf km
 
-deps: $(S6_BINS)
+deps: $(S6_BINS) $(ETCD_BINS)
 
-build: clean deps
+build: deps
 	cp -pv $(TARGET) .
 	$(SUDO) docker build -t $(REPO):$(TAG) .
 
@@ -40,5 +47,12 @@ s6:
 
 $(S6_BINS): s6
 	tar xzf _build/dist/$@
+
+etcd:
+	test 1 = 1 $(ETCD_BINS:%= -a -f "%") || ( \
+		curl -L -O $(ETCD_SOURCE) && tar xzvf $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz)
+
+$(ETCD_BINS): etcd
+	cp $@ .
 
 all:	push

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -1,7 +1,7 @@
 TARGET	?= /target/km
-IMAGE	?= km-dcos
-REPO	?= jdef/k8sm-$(IMAGE)
-TAG	?= 0.14.2-0.5-dev
+IMAGE	?= kubernetes
+REPO	?= mesosphere/$(IMAGE)
+TAG	?= k8s-0.14.2-k8sm-0.5-dcos-dev
 SUDO	?= $(shell test "$$(whoami)" = "root" || echo sudo)
 
 COMMON_ARCH ?= linux-amd64
@@ -53,6 +53,6 @@ etcd:
 		curl -L -O $(ETCD_SOURCE) && tar xzvf $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz)
 
 $(ETCD_BINS): etcd
-	cp $@ .
+	test -f "$$(basename $@)" || cp -v $@ .
 
 all:	push

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -13,6 +13,6 @@
 * webhook.sh - helper that can communicate with simple HTTP webhook endpoints
 
 ## TODO
-- [ ] process supervision for the executor is broken, dandling procs end up as children of slave
+- [x] process supervision for the executor is broken, dandling procs end up as children of slave
 - [ ] makes a big assumption about the location of etcd, need a better story here
 - [ ] s6 and k8s require files to exist in certain places on the host. this is terrible practice

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -15,4 +15,11 @@
 ## TODO
 - [x] process supervision for the executor is broken, dandling procs end up as children of slave
 - [ ] makes a big assumption about the location of etcd, need a better story here
+  - **STARTED:** probably want to support multiple deployment scenarios for etcd
+    - case 1: etcd cluster is deployed elsewhere and k8sm will tap into it
+    - case 2: etcd-server is deployed in the k8sm container, dies with the k8sm framework
+      - this can leave lingering exec's mapped to a framework that is not recognized if k8sm is redeployed
+      - [ ] etcd needs to start before everything else otherwise bad things happen (apiserver!)
 - [ ] s6 and k8s require files to exist in certain places on the host. this is terrible practice
+  - mentioned this article to elizabeth, she has similar concerns with the HDFS framework
+    - http://www.ibm.com/developerworks/library/l-mount-namespaces/

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -1,0 +1,18 @@
+## Usage
+```
+## build and push the docker image
+:; make push TARGET=$HOME/bin/km
+```
+
+## Files
+* Makefile - coordinate the build process: build s6, bundle it with km into a Docker and push the repo
+* Dockerfile - recipe for building the docker
+* bootstrap.sh - default target of Dockerfile, launches the framework: apiserver, scheduler, controller
+* executor.sh - wrapper script that runs the executor on a slave host
+* leapsecs.dat - requirement for s6 to work properly
+* webhook.sh - helper that can communicate with simple HTTP webhook endpoints
+
+## TODO
+- [ ] process supervision for the executor is broken, dandling procs end up as children of slave
+- [ ] makes a big assumption about the location of etcd, need a better story here
+- [ ] s6 and k8s require files to exist in certain places on the host. this is terrible practice

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -14,12 +14,14 @@
 
 ## TODO
 - [x] process supervision for the executor is broken, dandling procs end up as children of slave
-- [ ] makes a big assumption about the location of etcd, need a better story here
-  - **STARTED:** probably want to support multiple deployment scenarios for etcd
+- [x] makes a big assumption about the location of etcd, need a better story here
+  - support multiple deployment scenarios for etcd
     - case 1: etcd cluster is deployed elsewhere and k8sm will tap into it
     - case 2: etcd-server is deployed in the k8sm container, dies with the k8sm framework
       - this can leave lingering exec's mapped to a framework that is not recognized if k8sm is redeployed
-      - [ ] etcd needs to start before everything else otherwise bad things happen (apiserver!)
-- [ ] s6 and k8s require files to exist in certain places on the host. this is terrible practice
+      - [x] etcd needs to start before everything else otherwise bad things happen (apiserver!)
+- [x] s6 and k8s require files to exist in certain places on the host. this is terrible practice
   - mentioned this article to elizabeth, she has similar concerns with the HDFS framework
     - http://www.ibm.com/developerworks/library/l-mount-namespaces/
+- [ ] additional ports (e.g. 6443/apiserver) should be configurable
+- [ ] support secure (TLS) apiserver

--- a/hack/images/dcos/bootstrap.sh
+++ b/hack/images/dcos/bootstrap.sh
@@ -51,6 +51,9 @@ fi
 
 # run service procs as "nobody"
 apply_uids="s6-applyuidgid -u 99 -g 99"
+host_ip=$(echo $HOST | grep -e '[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+' >/dev/null 2>&1)
+test -n "$host_ip" || host_ip=$(lookup_ip "$HOST")
+echo host_ip=$host_ip
 
 #
 # create services directories and scripts
@@ -132,7 +135,7 @@ prepare_service ${monitor_dir} ${service_dir} apiserver ${APISERVER_RESPAWN_DELA
 fdmove -c 2 1
 $apply_uids
 /opt/km apiserver
-  --address=$HOST
+  --address=$host_ip
   --port=$apiserver_port
   --read_only_port=$apiserver_ro_port
   --mesos_master=${mesos_master}
@@ -151,10 +154,10 @@ prepare_service ${monitor_dir} ${service_dir} controller-manager ${CONTROLLER_MA
 fdmove -c 2 1
 $apply_uids
 /opt/km controller-manager
-  --address=$HOST
+  --address=$host_ip
   --port=$controller_manager_port
   --mesos_master=${mesos_master}
-  --master=http://$HOST:$apiserver_port
+  --master=http://$host_ip:$apiserver_port
   --v=${CONTROLLER_MANAGER_GLOG_v:-${logv}}
 EOF
 
@@ -177,7 +180,7 @@ prepare_service ${monitor_dir} ${service_dir} scheduler ${SCHEDULER_RESPAWN_DELA
 fdmove -c 2 1
 $apply_uids
 /opt/km scheduler $failover_timeout
-  --address=$HOST
+  --address=$host_ip
   --port=$scheduler_port
   --mesos_master=${mesos_master}
   --api_servers=http://${apiserver_host}:${apiserver_port}

--- a/hack/images/dcos/bootstrap.sh
+++ b/hack/images/dcos/bootstrap.sh
@@ -4,6 +4,7 @@ sandbox=${MESOS_SANDBOX:-${MESOS_DIRECTORY}}
 test -n "$sandbox" || die failed to identify mesos sandbox. neither MESOS_DIRECTORY or MESOS_SANDBOX was specified
 
 . /opt/functions.sh
+cp /opt/.version ${sandbox}
 
 mesos_leader=$(leading_master_ip) || die
 mesos_master=${mesos_leader}:5050
@@ -200,7 +201,9 @@ cd ${sandbox}
 echo "Self Extracting Installer"
 ARCHIVE=`awk "/^__ARCHIVE_BELOW__/ {print NR + 1; exit 0; }" $0`
 tail -n+$ARCHIVE $0 | tar xzv
-exec ./opt/executor.sh "$@"
+echo mounts before unshare:
+cat /proc/$$/mounts
+exec unshare -m -- ./opt/executor.sh "$@"
 __ARCHIVE_BELOW__'
 
 (cat executor-extractor; tar czf - -C / opt etc/leapsecs.dat usr bin sbin) >executor-installer.sh

--- a/hack/images/dcos/bootstrap.sh
+++ b/hack/images/dcos/bootstrap.sh
@@ -1,104 +1,5 @@
 #!/bin/sh
-die() {
-  test ${#} -eq 0 || echo "$@" >&2
-  exit 1
-}
-
-leading_master_ip() {
-  test -n "$K8SM_MESOS_MASTER" && {
-    echo $K8SM_MESOS_MASTER
-    return
-  }
-  local leader=$(nslookup leader.mesos | sed -e '/^Server:/,/^Address .*$/{ d }' -e '/^$/d'|grep -e '^Address '|cut -f3 -d' ')
-  test -n "$leader" || die Failed to identify mesos master, missing K8SM_MESOS_MASTER variable and cannot find leader.mesos
-  echo leader.mesos
-}
-
-prepare_var_run() {
-  local hostpath=/var/run/kubernetes
-  local run=${MESOS_SANDBOX}/run
-
-  test -L $hostpath && rm -f $hostpath
-  test -d $hostpath && rm -rf $hostpath  # should not happen, but...
-  test -f $hostpath && rm -f $hostpath   # should not happen, but...
-  mkdir -p $(dirname $hostpath) && mkdir -p $run && ln -s $run $hostpath && chown nobody:nobody $run
-}
-
-prepare_service_script() {
-  local svcdir=$1
-  local name=$2
-  local script=$3
-  mkdir -p ${svcdir}/${name} || die Failed to create service directory at $svcdir/$name
-  cat >${svcdir}/${name}/${script}
-  chmod +x ${svcdir}/${name}/${script}
-
-  test "$script" == "run" || return 0
-
-  s6-mkfifodir -f ${svcdir}/${name}/event
-
-  # only set up logging for run service scripts
-  mkdir -p $log_dir/$name
-  mkdir -p ${svcdir}/${name}/log
-  cat <<EOF >${svcdir}/${name}/log/run
-#!/usr/bin/execlineb
-s6-log ${log_args} $log_dir/$name
-EOF
-  chmod +x ${svcdir}/${name}/log/run
-
-  local loglink=log/$name/current
-  ln -sv $loglink ${MESOS_SANDBOX}/${name}.log
-
-  echo prepared script $script for service $name in dir $svcdir
-}
-
-prepare_monitor_script() {
-  local mondir=$1
-  local svcdir=$2
-  local name=$3
-
-  prepare_service_script ${mondir} ${name}-monitor run <<EOF
-#!/usr/bin/execlineb
-fdmove -c 2 1
-foreground {
-  s6-notifywhenup s6-ftrig-listen1 ${svcdir}/${name}/event u
-    echo waiting for ${name} service startup
-}
-foreground {
-  echo ${name} service started
-}
-loopwhilex
-  foreground {
-    s6-ftrig-listen1 ${svcdir}/${name}/event u
-      echo waiting for ${name} service restart
-  }
-  echo ${name} service restarted
-EOF
-}
-
-prepare_service() {
-  local mond="$1"
-  local svcd="$2"
-  local name="$3"
-  local respawnto="$4"
-
-  cat | prepare_service_script ${svcd} ${name} run
-  prepare_monitor_script ${mond} ${svcd} ${name}
-  prepare_service_script ${svcd} ${name} finish <<EOF
-#!/usr/bin/execlineb -S2
-foreground {
-  if { test "\${1}" != "256" }
-    foreground {
-      backtick -n ts { date "+%m%d %H:%M:%S.999999" }
-      import ts printf "I%s %7d respawn.xx:0] sleeping ${respawnto}s before respawning ${name}\\n" "\${ts}" "\${2}"
-    } sleep ${respawnto}
-}
-exit 0
-EOF
-}
-
-log_dir=${LOG_DIR:-$MESOS_SANDBOX/log}
-service_dir=${SERVICE_DIR:-$MESOS_SANDBOX/service.d}
-monitor_dir=${MONITOR_DIR:-$MESOS_SANDBOX/monitor.d}
+source /functions.sh
 
 mesos_leader=$(leading_master_ip) || die
 mesos_master=${mesos_leader}:5050
@@ -118,12 +19,6 @@ etcd_server_list=${ETCD_SERVER_LIST:-http://${service_proxy}:4001}
 # so it is important that this point to some frontend load balancer
 # of some sort, addressed by a fixed domain name or else a static IP.
 api_server=${KUBERNETES_MASTER:-http://${service_proxy}:8888}
-
-logv=${GLOG_v:-0}
-log_history=${LOG_HISTORY:-10}
-log_size=${LOG_SIZE:-2000000}
-
-log_args="-p -b n${log_history} s${log_size}"
 
 # run service procs as "nobody"
 apply_uids="s6-applyuidgid -u 99 -g 99"

--- a/hack/images/dcos/executor.sh
+++ b/hack/images/dcos/executor.sh
@@ -2,7 +2,29 @@
 #
 # usage: executor.sh {km-executor-parameters...}
 #
-source /functions.sh
+env
+
+sandbox=${MESOS_SANDBOX:-${MESOS_DIRECTORY}}
+test -n "$sandbox" || die failed to identify mesos sandbox. neither MESOS_DIRECTORY or MESOS_SANDBOX was specified
+
+execlineb_home=$sandbox
+. ${sandbox}/opt/functions.sh
+
+PATH=${sandbox}/bin:$PATH
+PATH=${sandbox}/sbin:$PATH
+PATH=${sandbox}/usr/bin:$PATH
+PATH=${sandbox}/usr/sbin:$PATH
+export PATH
+LD_LIBRARY_PATH=${sandbox}/lib
+export LD_LIBRARY_PATH
+#LD_DEBUG=all
+#export LD_DEBUG
+
+#TODO(jdef) if I uncomment this then things break, but I don't understand why - is something (the containerizer?)
+#messing with the argv list?
+#
+#test "$1" = "executor" || die Expected executor mode, not \"$1\"
+#shift
 
 mesos_leader=$(leading_master_ip) || die
 mesos_master=${mesos_leader}:5050
@@ -17,32 +39,36 @@ service_proxy=${SERVICE_PROXY:-${mesos_leader}}
 # of some sort, addressed by a fixed domain name or else a static IP.
 api_server=${KUBERNETES_MASTER:-http://${service_proxy}:8888}
 
+# executor startup will block until there is a reader on this FIFO, and then
+# executor communicates suicide by closing this FIFO
+shutdown_fifo=${sandbox}/shutdown_fifo
+
 mkdir -p ${log_dir}
 
-PATH=${MESOS_SANDBOX}/bin:$PATH
-PATH=${MESOS_SANDBOX}/sbin:$PATH
-PATH=${MESOS_SANDBOX}/usr/bin:$PATH
-PATH=${MESOS_SANDBOX}/usr/sbin:$PATH
-PATH=${MESOS_SANDBOX}/usr/local/bin:$PATH
-PATH=${MESOS_SANDBOX}/usr/local/sbin:$PATH
-export PATH
+#TODO(jdef): until there is a better way.. skalibs hardcodes the location of this file
+test -f /etc/leapsecs.dat || cp etc/leapsecs.dat /etc/
+test -d /usr/libexec || mkdir -p /usr/libexec
+test -L /usr/libexec/s6lockd-helper || ln -s ${sandbox}/usr/libexec/s6lockd-helper /usr/libexec/
 
 #
-# If suicide_fd is specified, executor startup should block, waiting for suicide_fd to be read from.
-# Upon suicide, executor closes suicidefd.
-# A sidecar script blocks, reading from suicidefd; upon close it sends termination signal to root s6 supervisor.
+# If shutdown_fd is specified, executor startup should block, waiting for shutdown_fd to be read from.
+# Upon suicide, executor closes shutdown_fd
+# A sidecar script blocks, reading from shutdown_fd; upon close it sends termination signal to root s6 supervisor.
 #
-# In this service script, we map a FD to the suicide_fifo, expecting that upon startup the
+# In this service script, we map a FD to the shutdown_fifo, expecting that upon startup the
 # executor will flip into blocking mode until there is a fifo reader (via redirfd -w n fifo)
 #
 prepare_service ${monitor_dir} ${service_dir} executor ${EXECUTOR_RESPAWN_DELAY:-3} <<EOF
-#!/usr/bin/execlineb
-fdmove -c 2 1
-fdreserve 1
-redirfd -w -nb $FD0 ${MESOS_SANDBOX}/suicide_fifo
-/km executor "${@}"
-  --run_proxy=false
-  --suicide_fd=$FD0
+#!/bin/sh
+exec 2>&1
+unset LD_LIBRARY_PATH
+exec redirfd -w -nb 3 $shutdown_fifo \\
+  ${sandbox}/opt/km executor ${@} \\
+    --run_proxy=false \\
+    --hostname_override=$LIBPROCESS_IP \\
+    --address=$LIBPROCESS_IP \\
+    --shutdown_fd=3 \\
+    --shutdown_fifo=$shutdown_fifo
 EOF
 
 #TODO: support these additional parameters at some point for the kube API client; should
@@ -55,21 +81,38 @@ EOF
 #  --v
 #  --master (should come from kubelet --apiservers list)
 #
+
+# if the proxy dies then it will send a shutdown signal to the executor.
+# TODO(jdef) probably don't want this behavior but I can't remember why I added it yesterday..
 prepare_service ${monitor_dir} ${service_dir} proxy ${PROXY_RESPAWN_DELAY:-3} <<EOF
-#!/usr/bin/execlineb
-fdmove -c 2 1
-/km proxy
-  --bind_address=${LIBPROCESS_IP:-0.0.0.0}
-  --logtostderr=true
+#!/bin/sh
+exec 2>&1
+bp=""
+
+teardown() {
+  local rc=\$?
+  test -n "\$bp" && kill \$bp
+  exit \$rc
+}
+
+trap teardown TERM
+
+redirfd -rnb 0 $shutdown_fifo foreground cat "" touch down &
+bp=\$!
+
+unset LD_LIBRARY_PATH
+${sandbox}/opt/km proxy \\
+  --bind_address=${LIBPROCESS_IP:-0.0.0.0} \\
+  --logtostderr=true \\
   --master=${KUBERNETES_MASTER}
+teardown
 EOF
 
 #
-# TODO: unsure how to handle executor suicide w/ s6 supervision; if the executor exits
-# then s6 will spin it back up because the executor exited NOT because of a signal that s6 sent.
-# ? should the executor accept an optional fd that it closes upon suicide?
+# handle executor suicide w/ s6 supervision; without special handling, if the executor exits then s6 will spin
+# it back up because the executor exited (and that's the job of s6)
 #
-# open a fifo for writing, instant success even there is no reader
+# pattern is this: open a fifo for writing, instant success even there is no reader
 #   redirfd -w -nb n fifo prog..
 #
 #   redirfd -w n fifo ...  # (blocks until the fifo is read)
@@ -77,22 +120,40 @@ EOF
 #   redirfd -rnb 0 fifo ... # Opening a fifo for reading, with instant success even if there is no writer, and blocking at the first attempt to read from it
 #   s6-log -bp t /mnt/tmpfs/uncaught-logs  # (reads from the blocked fifo)
 #
-# suppose executor accepts a --suicide_fd param
-# via..
-# fdreserve 2
-# multisubstitute
-# {
-#   importas fdr FD0
-#   importas fdw FD1
-#  }
-# piperw $fdr $fdw
-# prog...
+# If shutdown_fd is specified, executor startup should block, waiting for shutdown_fd to be read from.
+# Upon suicide, executor closes shutdown_fd
 #
-# If suicidefd is specified, executor startup should block, waiting for suicide_fd to be read from.
-# Upon suicide, executor closes suicidefd
+# Shutdown script blocks, reading from shutdown_fd; upon close it:
+# 1) disables the executor and proxy services
+# 2) waits for them to terminate
+# 3) sends termination signal to k8s service s6 supervisor.
 #
-# Sidecar script blocks, reading from suicidefd; upon close it sends termination signal to root s6 supervisor.
+# + root s6 supervisor
+# |-- km executor
+# |-- km proxy
+# |-- shutdown watcher
 #
+
+#--- shutdown watcher
+# 0) waits for shutdown FIFO
+# 1) waits for them to terminate
+#
+prepare_service_script ${service_dir} shutdown run <<EOF
+#!/bin/sh
+exec 2>&1
+echo awaiting shutdown signal
+exec redirfd -rnb 0 $shutdown_fifo foreground cat '' s6-svc -OD ${service_dir}/executor
+EOF
+
+# 2) sends termination signal to k8s service s6 supervisor.
+# the finish script can only live for 5s at most
+prepare_service_script ${service_dir} shutdown finish <<EOF
+#!/bin/sh
+touch down
+exec 2>&1
+echo shutdown finished \$*
+exec s6-scanctl -t ${service_dir}
+EOF
 
 #--- service monitor
 #
@@ -101,17 +162,32 @@ EOF
 # (2) after all monitors have reported "up" once,
 # (3) spawn the service tree
 #
-cd ${MESOS_SANDBOX}
+cd ${sandbox}
+mkdir -p init.d/s1
 
-cat <<EOF >monitor.sh
-#!/usr/bin/execlineb
-foreground {
-  s6-ftrig-listen -a {
-    ${monitor_dir}/apiserver-monitor/event U
-  } /usr/bin/s6-svscan -t${S6_RESCAN:-30000} ${monitor_dir}
+# TODO(jdef) the supervision hierarchy is messed up here: the monitor svscan escapes
+# and becomes owned by the slave instead of the top-level "init/s1" svscan
+cat <<EOF >init.d/s1/run
+#!/bin/sh
+die() {
+  local rc=\$?
+  echo \$* >&2
+  exit \$rc
 }
-/usr/bin/s6-svscan -t${S6_RESCAN:-30000} ${service_dir}
+s6-ftrig-listen -a \
+  ${monitor_dir}/executor-monitor/event U \
+  ${monitor_dir}/proxy-monitor/event U \
+  '' s6-svscan -t${S6_RESCAN:-30000} ${monitor_dir} || die monitoring s6-ftrig-listen exited \$?
+exec s6-svscan -t${S6_RESCAN:-30000} ${service_dir}
 EOF
+chmod +x init.d/s1/run
 
-chmod +x monitor.sh
-exec ./monitor.sh
+cat <<EOF >init.d/s1/finish
+#!/bin/sh
+touch down
+echo executor terminating \$*
+exec s6-scanctl -t ${sandbox}/init
+EOF
+chmod +x init.d/s1/finish
+
+exec s6-svscan init.d

--- a/hack/images/dcos/executor.sh
+++ b/hack/images/dcos/executor.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+#
+# usage: executor.sh {km-executor-parameters...}
+#
+source /functions.sh
+
+mesos_leader=$(leading_master_ip) || die
+mesos_master=${mesos_leader}:5050
+
+# assume that the leading mesos master is always running a marathon
+# service proxy, perhaps using haproxy.
+service_proxy=${SERVICE_PROXY:-${mesos_leader}}
+
+# would be nice if this was auto-discoverable. if this value changes
+# between launches of the framework, there can be dangling executors,
+# so it is important that this point to some frontend load balancer
+# of some sort, addressed by a fixed domain name or else a static IP.
+api_server=${KUBERNETES_MASTER:-http://${service_proxy}:8888}
+
+mkdir -p ${log_dir}
+
+PATH=${MESOS_SANDBOX}/bin:$PATH
+PATH=${MESOS_SANDBOX}/sbin:$PATH
+PATH=${MESOS_SANDBOX}/usr/bin:$PATH
+PATH=${MESOS_SANDBOX}/usr/sbin:$PATH
+PATH=${MESOS_SANDBOX}/usr/local/bin:$PATH
+PATH=${MESOS_SANDBOX}/usr/local/sbin:$PATH
+export PATH
+
+#
+# If suicide_fd is specified, executor startup should block, waiting for suicide_fd to be read from.
+# Upon suicide, executor closes suicidefd.
+# A sidecar script blocks, reading from suicidefd; upon close it sends termination signal to root s6 supervisor.
+#
+# In this service script, we map a FD to the suicide_fifo, expecting that upon startup the
+# executor will flip into blocking mode until there is a fifo reader (via redirfd -w n fifo)
+#
+prepare_service ${monitor_dir} ${service_dir} executor ${EXECUTOR_RESPAWN_DELAY:-3} <<EOF
+#!/usr/bin/execlineb
+fdmove -c 2 1
+fdreserve 1
+redirfd -w -nb $FD0 ${MESOS_SANDBOX}/suicide_fifo
+/km executor "${@}"
+  --run_proxy=false
+  --suicide_fd=$FD0
+EOF
+
+#TODO: support these additional parameters at some point for the kube API client; should
+# be able to scrape these from the executor args list?
+#  --api_version=
+#  --client_certificate=
+#  --client_key=
+#  --certificate_authority=
+#  --insecure_skip_tls_verify=
+#  --v
+#  --master (should come from kubelet --apiservers list)
+#
+prepare_service ${monitor_dir} ${service_dir} proxy ${PROXY_RESPAWN_DELAY:-3} <<EOF
+#!/usr/bin/execlineb
+fdmove -c 2 1
+/km proxy
+  --bind_address=${LIBPROCESS_IP:-0.0.0.0}
+  --logtostderr=true
+  --master=${KUBERNETES_MASTER}
+EOF
+
+#
+# TODO: unsure how to handle executor suicide w/ s6 supervision; if the executor exits
+# then s6 will spin it back up because the executor exited NOT because of a signal that s6 sent.
+# ? should the executor accept an optional fd that it closes upon suicide?
+#
+# open a fifo for writing, instant success even there is no reader
+#   redirfd -w -nb n fifo prog..
+#
+#   redirfd -w n fifo ...  # (blocks until the fifo is read)
+# ... later
+#   redirfd -rnb 0 fifo ... # Opening a fifo for reading, with instant success even if there is no writer, and blocking at the first attempt to read from it
+#   s6-log -bp t /mnt/tmpfs/uncaught-logs  # (reads from the blocked fifo)
+#
+# suppose executor accepts a --suicide_fd param
+# via..
+# fdreserve 2
+# multisubstitute
+# {
+#   importas fdr FD0
+#   importas fdw FD1
+#  }
+# piperw $fdr $fdw
+# prog...
+#
+# If suicidefd is specified, executor startup should block, waiting for suicide_fd to be read from.
+# Upon suicide, executor closes suicidefd
+#
+# Sidecar script blocks, reading from suicidefd; upon close it sends termination signal to root s6 supervisor.
+#
+
+#--- service monitor
+#
+# (0) subscribe to monitor "up" events
+# (1) fork service monitors
+# (2) after all monitors have reported "up" once,
+# (3) spawn the service tree
+#
+cd ${MESOS_SANDBOX}
+
+cat <<EOF >monitor.sh
+#!/usr/bin/execlineb
+foreground {
+  s6-ftrig-listen -a {
+    ${monitor_dir}/apiserver-monitor/event U
+  } /usr/bin/s6-svscan -t${S6_RESCAN:-30000} ${monitor_dir}
+}
+/usr/bin/s6-svscan -t${S6_RESCAN:-30000} ${service_dir}
+EOF
+
+chmod +x monitor.sh
+exec ./monitor.sh

--- a/hack/images/dcos/functions.sh
+++ b/hack/images/dcos/functions.sh
@@ -8,10 +8,6 @@ die() {
 }
 
 lookup_ip() {
-  test -n "$K8SM_MESOS_MASTER" && {
-    echo $K8SM_MESOS_MASTER
-    return
-  }
   local leader=$(nslookup "$1" | sed -e '/^Server:/,/^Address .*$/{ d }' -e '/^$/d'|grep -e '^Address '|cut -f3 -d' '|head -1)
   test -n "$leader" || die Failed to identify $1
   echo $leader

--- a/hack/images/dcos/functions.sh
+++ b/hack/images/dcos/functions.sh
@@ -23,6 +23,9 @@ leading_master_ip() {
   echo leader.mesos
 }
 
+# NOTE: this is really intended only for the apiserver since it runs in a
+# docker CT and has r/w access to the root file system, unlike the executor
+# proxy services.
 prepare_var_run() {
   local hostpath=/var/run/kubernetes
   local run=${sandbox}/run

--- a/hack/images/dcos/functions.sh
+++ b/hack/images/dcos/functions.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+die() {
+  test ${#} -eq 0 || echo "$@" >&2
+  exit 1
+}
+
+leading_master_ip() {
+  test -n "$K8SM_MESOS_MASTER" && {
+    echo $K8SM_MESOS_MASTER
+    return
+  }
+  local leader=$(nslookup leader.mesos | sed -e '/^Server:/,/^Address .*$/{ d }' -e '/^$/d'|grep -e '^Address '|cut -f3 -d' ')
+  test -n "$leader" || die Failed to identify mesos master, missing K8SM_MESOS_MASTER variable and cannot find leader.mesos
+  echo leader.mesos
+}
+
+prepare_var_run() {
+  local hostpath=/var/run/kubernetes
+  local run=${MESOS_SANDBOX}/run
+
+  test -L $hostpath && rm -f $hostpath
+  test -d $hostpath && rm -rf $hostpath  # should not happen, but...
+  test -f $hostpath && rm -f $hostpath   # should not happen, but...
+  mkdir -p $(dirname $hostpath) && mkdir -p $run && ln -s $run $hostpath && chown nobody:nobody $run
+}
+
+prepare_service_script() {
+  local svcdir=$1
+  local name=$2
+  local script=$3
+  mkdir -p ${svcdir}/${name} || die Failed to create service directory at $svcdir/$name
+  cat >${svcdir}/${name}/${script}
+  chmod +x ${svcdir}/${name}/${script}
+
+  test "$script" == "run" || return 0
+
+  s6-mkfifodir -f ${svcdir}/${name}/event
+
+  # only set up logging for run service scripts
+  mkdir -p $log_dir/$name
+  mkdir -p ${svcdir}/${name}/log
+  cat <<EOF >${svcdir}/${name}/log/run
+#!/usr/bin/execlineb
+s6-log ${log_args} $log_dir/$name
+EOF
+  chmod +x ${svcdir}/${name}/log/run
+
+  local loglink=log/$name/current
+  ln -sv $loglink ${MESOS_SANDBOX}/${name}.log
+
+  echo prepared script $script for service $name in dir $svcdir
+}
+
+prepare_monitor_script() {
+  local mondir=$1
+  local svcdir=$2
+  local name=$3
+
+  prepare_service_script ${mondir} ${name}-monitor run <<EOF
+#!/usr/bin/execlineb
+fdmove -c 2 1
+foreground {
+  s6-notifywhenup s6-ftrig-listen1 ${svcdir}/${name}/event u
+    echo waiting for ${name} service startup
+}
+foreground {
+  echo ${name} service started
+}
+loopwhilex
+  foreground {
+    s6-ftrig-listen1 ${svcdir}/${name}/event u
+      echo waiting for ${name} service restart
+  }
+  echo ${name} service restarted
+EOF
+}
+
+prepare_service() {
+  local mond="$1"
+  local svcd="$2"
+  local name="$3"
+  local respawnSec="$4"
+
+  cat | prepare_service_script ${svcd} ${name} run
+  prepare_monitor_script ${mond} ${svcd} ${name}
+  prepare_service_script ${svcd} ${name} finish <<EOF
+#!/usr/bin/execlineb -S2
+foreground {
+  if { test "\${1}" != "256" }
+    foreground {
+      backtick -n ts { date "+%m%d %H:%M:%S.999999" }
+      import ts printf "I%s %7d respawn.xx:0] sleeping ${respawnSec}s before respawning ${name}\\n" "\${ts}" "\${2}"
+    } sleep ${respawnSec}
+}
+exit 0
+EOF
+}
+
+log_dir=${LOG_DIR:-$MESOS_SANDBOX/log}
+monitor_dir=${MONITOR_DIR:-$MESOS_SANDBOX/monitor.d}
+service_dir=${SERVICE_DIR:-$MESOS_SANDBOX/service.d}
+
+log_history=${LOG_HISTORY:-10}
+log_size=${LOG_SIZE:-2000000}
+log_args="-p -b n${log_history} s${log_size}"
+logv=${GLOG_v:-0}

--- a/hack/images/dcos/functions.sh
+++ b/hack/images/dcos/functions.sh
@@ -7,6 +7,16 @@ die() {
   exit 1
 }
 
+lookup_ip() {
+  test -n "$K8SM_MESOS_MASTER" && {
+    echo $K8SM_MESOS_MASTER
+    return
+  }
+  local leader=$(nslookup "$1" | sed -e '/^Server:/,/^Address .*$/{ d }' -e '/^$/d'|grep -e '^Address '|cut -f3 -d' '|head -1)
+  test -n "$leader" || die Failed to identify $1
+  echo $leader
+}
+
 leading_master_ip() {
   test -n "$K8SM_MESOS_MASTER" && {
     echo $K8SM_MESOS_MASTER

--- a/hack/test_redirfd.sh
+++ b/hack/test_redirfd.sh
@@ -1,0 +1,82 @@
+#!/bin/bash -vx
+ontrap() {
+	local rc=$?
+	test -n "$file" -a -f "$file" && rm -f "$file"
+	exit $rc
+}
+
+trap ontrap EXIT
+
+die() {
+	echo "ERROR: $*" >&2
+	exit 1
+}
+# open a fifo for writing, instant success even there is no reader
+#   redirfd -w -nb n fifo prog..
+#
+#   redirfd -w n fifo ...  # (blocks until the fifo is read)
+# ... later
+#   redirfd -rnb 0 fifo ... # Opening a fifo for reading, with instant success even if there is no writer, and blocking at the first attempt to read from it
+#   s6-log -bp t /mnt/tmpfs/uncaught-logs  # (reads from the blocked fifo)
+redir=$(dirname $0)/../_build/bin/k8sm-redirfd
+test -x $redir || die echo "missing $redir"
+
+#
+# black magic testing
+#
+($redir -n -b w  1 /tmp/fifo1 echo "fifo was read") &
+
+for i in {1..2}; do echo sleeping $i; sleep 1; done
+
+$redir -n -b r 0 /tmp/fifo1 cat
+wait
+
+#
+# test simple input redirection
+#
+file=/tmp/file1.$$
+echo "file contents" >$file
+x=$($redir r 0 $file cat)
+test "$x" = "file contents" || die Invalid contents of $file
+rm -f $file
+
+#
+# test simple output redirection
+#
+file=/tmp/file2
+$redir w 1 $file echo "hello james" || die Failed to redirect output to $file
+test "$(cat $file)" = "hello james" || die Rediect output: file contents mismatch .. $file
+rm -f $file
+
+file=/tmp/file2.1
+echo "anna" >$file
+$redir w 1 $file echo "hello james" || die Failed to redirect output to $file
+test "$(cat $file)" = "hello james" || die Rediect output: file contents mismatch .. $file
+rm -f $file
+
+file=/tmp/file3
+echo -n "bill " >$file
+$redir a 1 $file echo "hello james" || die Failed to redirect output to $file
+test "$(cat $file)" = "bill hello james" || die Rediect output: file contents mismatch .. $file
+rm -f $file
+
+file=/tmp/file4
+$redir c 1 $file echo "hello james" && die Expected redirect output to fail for $file
+rm -f $file
+
+file=/tmp/file5
+echo -n "bill " >$file
+$redir c 1 $file echo "hello james" || die Failed to redirect output to $file
+test "$(cat $file)" = "bill hello james" || die Rediect output: file contents mismatch .. $file
+rm -f $file
+
+file=/tmp/file6
+echo -n "bill " >$file
+$redir x 1 $file echo "hello james" && die Expected redirect output to fail for $file
+rm -f $file
+
+file=/tmp/file7
+$redir x 1 $file echo "hello james" || die Failed to redirect output to $file
+test "$(cat $file)" = "hello james" || die Rediect output: file contents mismatch .. $file
+rm -f $file
+

--- a/pkg/cloud/mesos/mesos.go
+++ b/pkg/cloud/mesos/mesos.go
@@ -82,14 +82,18 @@ func (c *MesosCloud) ipAddress(name string) (net.IP, error) {
 	if name == "" {
 		return nil, noHostNameSpecified
 	}
-	if iplist, err := net.LookupIP(name); err != nil {
-		log.V(2).Infof("failed to resolve IP from host name '%v': %v", name, err)
-		return nil, err
-	} else {
-		ipaddr := iplist[0]
-		log.V(2).Infof("resolved host '%v' to '%v'", name, ipaddr)
+	ipaddr := net.ParseIP(name)
+	if ipaddr != nil {
 		return ipaddr, nil
 	}
+	iplist, err := net.LookupIP(name)
+	if err != nil {
+		log.V(2).Infof("failed to resolve IP from host name '%v': %v", name, err)
+		return nil, err
+	}
+	ipaddr = iplist[0]
+	log.V(2).Infof("resolved host '%v' to '%v'", name, ipaddr)
+	return ipaddr, nil
 }
 
 // ExternalID returns the cloud provider ID of the specified instance.

--- a/pkg/cloud/mesos/mesos_test.go
+++ b/pkg/cloud/mesos/mesos_test.go
@@ -1,0 +1,44 @@
+package mesos
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestIPAddress(t *testing.T) {
+	c := &MesosCloud{}
+	expected4 := net.IPv4(127, 0, 0, 1)
+	ip, err := c.ipAddress("127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(ip, expected4) {
+		t.Fatalf("expected %#v instead of %#v", expected4, ip)
+	}
+
+	expected6 := net.ParseIP("::1")
+	if expected6 == nil {
+		t.Fatalf("failed to parse ipv6 ::1")
+	}
+	ip, err = c.ipAddress("::1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(ip, expected6) {
+		t.Fatalf("expected %#v instead of %#v", expected6, ip)
+	}
+
+	ip, err = c.ipAddress("localhost")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(ip, expected4) && !reflect.DeepEqual(ip, expected6) {
+		t.Fatalf("expected %#v or %#v instead of %#v", expected4, expected6, ip)
+	}
+
+	_, err = c.ipAddress("")
+	if err != noHostNameSpecified {
+		t.Fatalf("expected error noHostNameSpecified but got none")
+	}
+}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -97,7 +97,7 @@ type KubernetesExecutor struct {
 	dockerClient        dockertools.DockerInterface
 	suicideWatch        suicideWatcher
 	suicideTimeout      time.Duration
-	shutdownAlert       func()          // invoked just prior to executor shutdown by suicide
+	shutdownAlert       func()          // invoked just prior to executor shutdown
 	kubeletFinished     <-chan struct{} // signals that kubelet Run() died
 	initialRegistration sync.Once
 }

--- a/pkg/executor/service/service.go
+++ b/pkg/executor/service/service.go
@@ -106,7 +106,9 @@ func (s *KubeletExecutorServer) AddHyperkubeFlags(fs *pflag.FlagSet) {
 	s.addCoreFlags(fs)
 }
 
-// returns a Closer that should be closed to signal impending shutdown, but only if ShutdownFD and ShutdownFIFO were specified.
+// returns a Closer that should be closed to signal impending shutdown, but only if ShutdownFD
+// and ShutdownFIFO were specified. if they are specified, then this func blocks until there's
+// a reader on the FIFO stream.
 func (s *KubeletExecutorServer) syncExternalShutdownWatcher() (io.Closer, error) {
 	if s.ShutdownFD == -1 || s.ShutdownFIFO == "" {
 		return nil, nil

--- a/pkg/offers/offers_test.go
+++ b/pkg/offers/offers_test.go
@@ -84,8 +84,8 @@ func TestOfferStorage(t *testing.T) {
 		Compat: func(o *mesos.Offer) bool {
 			return o.Hostname == nil || *o.Hostname != "incompatiblehost"
 		},
-		TTL:           ttl,
-		LingerTTL:     2 * ttl,
+		TTL:       ttl,
+		LingerTTL: 2 * ttl,
 	}
 	storage := CreateRegistry(config)
 
@@ -168,7 +168,7 @@ func TestOfferStorage(t *testing.T) {
 	// Incompatible offer is declined
 	id = util.NewOfferID("foo4")
 	incompatibleHostname := "incompatiblehost"
-	o = &mesos.Offer{Id: id, Hostname:&incompatibleHostname}
+	o = &mesos.Offer{Id: id, Hostname: &incompatibleHostname}
 	declinedNumBefore = declinedNum
 	storage.Add([]*mesos.Offer{o})
 	if obj, ok := storage.Get(id.GetValue()); obj != nil || ok {
@@ -213,7 +213,7 @@ func TestOfferStorage(t *testing.T) {
 	// InvalidateForSlave invalides all offers for that slave, but only those
 	id = util.NewOfferID("foo8")
 	slaveId := util.NewSlaveID("test-slave")
-	o = &mesos.Offer{Id: id, SlaveId:slaveId}
+	o = &mesos.Offer{Id: id, SlaveId: slaveId}
 	storage.Add([]*mesos.Offer{o})
 	id2 = util.NewOfferID("foo9")
 	o2 = &mesos.Offer{Id: id2}
@@ -243,7 +243,7 @@ func TestListen(t *testing.T) {
 	}
 	storage := CreateRegistry(config)
 
-	done := make(chan struct {})
+	done := make(chan struct{})
 	storage.Init(done)
 
 	// Create two listeners with a hostname filter
@@ -258,7 +258,7 @@ func TestListen(t *testing.T) {
 
 	// Add hostname1 offer
 	id := util.NewOfferID("foo")
-	o := &mesos.Offer{Id: id, Hostname:&hostname1}
+	o := &mesos.Offer{Id: id, Hostname: &hostname1}
 	storage.Add([]*mesos.Offer{o})
 
 	// listener1 is notified by closing channel
@@ -271,9 +271,9 @@ func TestListen(t *testing.T) {
 
 	// listener2 is not notified within ttl
 	select {
-		case <-listener2:
-			t.Error("listener2 is notified")
-		case <-time.After(ttl):
+	case <-listener2:
+		t.Error("listener2 is notified")
+	case <-time.After(ttl):
 	}
 
 	close(done)

--- a/pkg/redirfd/doc.go
+++ b/pkg/redirfd/doc.go
@@ -1,0 +1,3 @@
+// Some file descriptor manipulation funcs, inspired by
+// https://github.com/skarnet/execline/blob/master/src/execline/redirfd.c
+package redirfd

--- a/pkg/redirfd/redirfd.go
+++ b/pkg/redirfd/redirfd.go
@@ -1,0 +1,184 @@
+package redirfd
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+type RedirectMode int
+
+const (
+	Read           RedirectMode = iota // open file for reading
+	Write                              // open file for writing, truncating if it exists
+	Update                             // open file for read & write
+	Append                             // open file for append, create if it does not exist
+	AppendExisting                     // open file for append, do not create if it does not already exist
+	WriteNew                           // open file for writing, creating it, failing if it already exists
+)
+
+// see https://github.com/skarnet/execline/blob/master/src/execline/redirfd.c
+func (mode RedirectMode) Redirect(nonblock, changemode bool, fd int, name string) (*os.File, error) {
+	flags := 0
+	what := -1
+
+	switch mode {
+	case Read:
+		what = syscall.O_RDONLY
+		flags &= ^(syscall.O_APPEND | syscall.O_CREAT | syscall.O_TRUNC | syscall.O_EXCL)
+	case Write:
+		what = syscall.O_WRONLY
+		flags |= syscall.O_CREAT | syscall.O_TRUNC
+		flags &= ^(syscall.O_APPEND | syscall.O_EXCL)
+	case Update:
+		what = syscall.O_RDWR
+		flags &= ^(syscall.O_APPEND | syscall.O_CREAT | syscall.O_TRUNC | syscall.O_EXCL)
+	case Append:
+		what = syscall.O_WRONLY
+		flags |= syscall.O_CREAT | syscall.O_APPEND
+		flags &= ^(syscall.O_TRUNC | syscall.O_EXCL)
+	case AppendExisting:
+		what = syscall.O_WRONLY
+		flags |= syscall.O_APPEND
+		flags &= ^(syscall.O_CREAT | syscall.O_TRUNC | syscall.O_EXCL)
+	case WriteNew:
+		what = syscall.O_WRONLY
+		flags |= syscall.O_CREAT | syscall.O_EXCL
+		flags &= ^(syscall.O_APPEND | syscall.O_TRUNC)
+	default:
+		return nil, fmt.Errorf("unexpected mode %d", mode)
+	}
+	if nonblock {
+		flags |= syscall.O_NONBLOCK
+	}
+	flags |= what
+
+	fd2, e := syscall.Open(name, flags, 0666)
+	if (what == syscall.O_WRONLY) && (e == syscall.ENXIO) {
+		// Opens file in read-only, non-blocking mode. Returns a valid fd number if it succeeds, or -1 (and sets errno) if it fails.
+		fdr, e2 := syscall.Open(name, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)
+		if e2 != nil {
+			return nil, &os.PathError{"open_read", name, e2}
+		}
+		fd2, e = syscall.Open(name, flags, 0666)
+		fd_close(fdr)
+	}
+	if e != nil {
+		return nil, &os.PathError{"open", name, e}
+	}
+	if e = fd_move(fd, fd2); e != nil {
+		return nil, &os.PathError{"fd_move", name, e}
+	}
+	if changemode {
+		if nonblock {
+			e = ndelay_off(fd)
+		} else {
+			e = ndelay_on(fd)
+		}
+		if e != nil {
+			return nil, &os.PathError{"ndelay", name, e}
+		}
+	}
+	return os.NewFile(uintptr(fd2), name), nil
+}
+
+// see https://github.com/skarnet/skalibs/blob/master/src/libstddjb/fd_move.c
+func fd_move(to, from int) (err error) {
+	if to == from {
+		return
+	}
+	for {
+		_, _, e1 := syscall.RawSyscall(syscall.SYS_DUP2, uintptr(from), uintptr(to), 0)
+		if e1 != syscall.EINTR {
+			if e1 != 0 {
+				err = e1
+			}
+			break
+		}
+	}
+	if err != nil {
+		err = fd_close(from)
+	}
+	return
+	/*
+	   do
+	     r = dup2(from, to) ;
+	   while ((r == -1) && (errno == EINTR)) ;
+	   return (r == -1) ? -1 : fd_close(from) ;
+	*/
+}
+
+// see https://github.com/skarnet/skalibs/blob/master/src/libstddjb/fd_close.c
+func fd_close(fd int) (err error) {
+	i := 0
+	var e error
+	for {
+		if e = syscall.Close(fd); e != nil {
+			return nil
+		}
+		i++
+		if e != syscall.EINTR {
+			break
+		}
+	}
+	if e == syscall.EBADF && i > 1 {
+		return nil
+	}
+	return e
+}
+
+/*
+int fd_close (int fd)
+{
+  register unsigned int i = 0 ;
+doit:
+  if (!close(fd)) return 0 ;
+  i++ ;
+  if (errno == EINTR) goto doit ;
+  return ((errno == EBADF) && (i > 1)) ? 0 : -1 ;
+}
+*/
+
+// see https://github.com/skarnet/skalibs/blob/master/src/libstddjb/ndelay_on.c
+func ndelay_on(fd int) error {
+	// 32-bit will likely break because it needs SYS_FCNTL64
+	got, _, e := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_GETFL), 0)
+	if e != 0 {
+		return e
+	}
+	_, _, e = syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_SETFL), uintptr(got|syscall.O_NONBLOCK))
+	if e != 0 {
+		return e
+	}
+	return nil
+}
+
+/*
+int ndelay_on (int fd)
+{
+  register int got = fcntl(fd, F_GETFL) ;
+  return (got == -1) ? -1 : fcntl(fd, F_SETFL, got | O_NONBLOCK) ;
+}
+*/
+
+// see https://github.com/skarnet/skalibs/blob/master/src/libstddjb/ndelay_off.c
+func ndelay_off(fd int) error {
+	// 32-bit will likely break because it needs SYS_FCNTL64
+	got, _, e := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_GETFL), 0)
+	if e != 0 {
+		return e
+	}
+	_, _, e = syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_SETFL), uintptr(int(got) & ^syscall.O_NONBLOCK))
+	if e != 0 {
+		return e
+	}
+	return nil
+}
+
+/*
+int ndelay_off (int fd)
+{
+  register int got = fcntl(fd, F_GETFL) ;
+  return (got == -1) ? -1 : fcntl(fd, F_SETFL, got & ^O_NONBLOCK) ;
+}
+*/

--- a/pkg/scheduler/podtask/pod_task.go
+++ b/pkg/scheduler/podtask/pod_task.go
@@ -109,9 +109,17 @@ func (t *T) GetOfferId() string {
 	return t.Offer.Details().Id.GetValue()
 }
 
+func generateTaskName(pod *api.Pod) string {
+	ns := pod.Namespace
+	if ns == "" {
+		ns = api.NamespaceDefault
+	}
+	return fmt.Sprintf("%s.%s.pods", pod.Name, ns)
+}
+
 func (t *T) BuildTaskInfo() *mesos.TaskInfo {
 	info := &mesos.TaskInfo{
-		Name:     proto.String("pod"), // TODO(jdef) encode pod namespace,name
+		Name:     proto.String(generateTaskName(&t.Pod)),
 		TaskId:   mutil.NewTaskID(t.ID),
 		SlaveId:  mutil.NewSlaveID(t.Spec.SlaveID),
 		Executor: t.executor,

--- a/pkg/scheduler/podtask/pod_task_test.go
+++ b/pkg/scheduler/podtask/pod_task_test.go
@@ -154,3 +154,24 @@ func TestAcceptOfferPorts(t *testing.T) {
 		t.Fatalf("accepted offer %v:", offer)
 	}
 }
+
+func TestGeneratePodName(t *testing.T) {
+	p := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+		},
+	}
+	name := generateTaskName(p)
+	expected := "foo.bar.pods"
+	if name != expected {
+		t.Fatalf("expected %q instead of %q", expected, name)
+	}
+
+	p.Namespace = ""
+	name = generateTaskName(p)
+	expected = "foo.default.pods"
+	if name != expected {
+		t.Fatalf("expected %q instead of %q", expected, name)
+	}
+}


### PR DESCRIPTION
- wrapper scripts modified to comply with dcos environment constraints
  - new issues have cropped up: #249, #250 
- proper process supervision, both for docker container (etcd,apiserver,scheduler,controller) and native mesos container (executor/proxy)
  - resolves #91
- proper log rotation for all k8s services
  - fixes #228
- private mount namespace for executor container
- single nginx pod launches on k8sm running on top of dcos
  - fixes #241 