### PR TITLE
Start mesos cloud provider on controller manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ $ ./bin/km apiserver \
 
 $ ./bin/km controller-manager \
   --master=$servicehost:8888 \
+  --cloud_provider=mesos \
   --cloud_config=./mesos-cloud.conf \
   --v=2 >controller.log 2>&1 &
 


### PR DESCRIPTION
In the README.md --cloud_provider=mesos was missing for the controller manager.
Hence, the k8s nodecontroller didn't call our Instances method to return the nodes.
The result was a node list without LegacyHostIP.

Possibly fixes #268