### PR TITLE
DCOS release improvements

### DIFF
--- a/hack/images/dcos/.gitignore
+++ b/hack/images/dcos/.gitignore
@@ -2,6 +2,7 @@ usr
 km
 etcd*
 .version
+dockertag
 kubectl
 skydns-rc.yaml.in
 skydns-svc.yaml.in

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -48,7 +48,7 @@ DCOS_PREFIX ?= k8s-0.14.2-k8sm-0.5-dcos
 TAG	?= $(DCOS_PREFIX)-$(DCOS_VERSION)
 FQIN	?= $(REPO):$(TAG)
 
-.PHONY:	clean build push s6 $(S6_BINS) deps etcd $(ETCD_BINS) $(KUBE_DNS_TEMPLATES) version release promote
+.PHONY:	clean build push s6 $(S6_BINS) deps etcd $(ETCD_BINS) $(KUBE_DNS_TEMPLATES) version release promote check-sudo-docker info
 
 all:	build
 
@@ -60,16 +60,16 @@ deps: $(S6_BINS) $(ETCD_BINS) $(KUBE_DNS_TEMPLATES)
 version:
 	@echo "$(RELEASE_VERSION)" | tee .version
 
-build: deps version
+build: deps version check-sudo-docker
 	cp -pv $(TARGET_OBJ:%=$(FROM)/%) .
 	@echo $(FQIN) >dockertag
 	$(SUDO) docker build -q -t $$(cat dockertag) .
 
-push:
+push: check-sudo-docker
 	(dockertag=$$(cat dockertag); echo pushing $$dockertag; $(SUDO) docker push $$dockertag)
 
 # would be nice to validate that the image contains .version that matches what's in the dir
-promote:
+promote: check-sudo-docker
 	echo $(REPO):$(DCOS_PREFIX)-$$(cat .version) >dockertag
 	(dockertag=$$(cat dockertag); echo promoting $$dockertag; $(SUDO) docker tag -f $(REPO):$(DCOS_PREFIX)-dev $$dockertag) && \
 	$(MAKE) push
@@ -77,7 +77,7 @@ promote:
 release:
 	$(MAKE) build push FROM=$(FROM) RELEASE=$(RELEASE)
 
-s6:
+s6: check-sudo-docker
 	mkdir -pv _build/s6 _build/dist && chmod -v o+rw _build/dist
 	test -f _build/s6/.gitignore || git clone --depth=1 $(S6_GIT) _build/s6
 	test -f _build/dist/manifest.txt || ( \
@@ -99,3 +99,10 @@ $(KUBE_DNS_TEMPLATES): $(KUBE_DNS_TEMPLATES_SOURCES)
 
 $(KUBE_DNS_TEMPLATES_SOURCES):
 
+check-sudo-docker:
+	@$(SUDO) docker version >/dev/null || (echo You do not have privileges to execute \"$(SUDO) docker\" commands, or else docker is not properly installed/configured >&2; exit 1)
+
+info: check-sudo-docker
+	@$(SUDO) docker version
+	@echo ".version : $$(cat .version 2>/dev/null)"
+	@echo "dockertag: $$(cat dockertag 2>/dev/null)"

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -2,7 +2,7 @@ FROM	?= /target
 TARGET_OBJ = km kubectl
 IMAGE	?= kubernetes
 REPO	?= mesosphere/$(IMAGE)
-TAG	?= k8s-0.14.2-k8sm-0.5-dcos-dev
+DCOS_VERSION ?= dev
 SUDO	?= $(shell test "$$(whoami)" = "root" || echo sudo)
 
 COMMON_ARCH ?= linux-amd64
@@ -27,7 +27,28 @@ KUBE_DNS_TEMPLATES_SOURCES = $(KUBE_DNS_TEMPLATES:%=../dns/%)
 
 S6_BINS ?= $(S6_OBJ) $(EXECLINE_OBJ)
 
-.PHONY:	clean build push s6 $(S6_BINS) deps etcd $(ETCD_BINS) $(KUBE_DNS_TEMPLATES)
+#
+# normally you'll be generating dev images via:
+#	make release 
+#
+# and promoting (re-tagging them with a release version) them via:
+#	make promote
+#
+# HOWEVER, to generate a fresh release image and push it up (skip the -dev tag cycle):
+#	make release FROM=~/bin RELEASE=1
+#
+RELEASE ?=
+RELEASE_VERSION ?= $(shell date -Iseconds | sed -e 's/[-:+]//g')
+
+ifneq ($(RELEASE),)
+DCOS_VERSION = $(RELEASE_VERSION)
+endif
+
+DCOS_PREFIX ?= k8s-0.14.2-k8sm-0.5-dcos
+TAG	?= $(DCOS_PREFIX)-$(DCOS_VERSION)
+FQIN	?= $(REPO):$(TAG)
+
+.PHONY:	clean build push s6 $(S6_BINS) deps etcd $(ETCD_BINS) $(KUBE_DNS_TEMPLATES) version release promote
 
 all:	build
 
@@ -36,13 +57,25 @@ clean:
 
 deps: $(S6_BINS) $(ETCD_BINS) $(KUBE_DNS_TEMPLATES)
 
-build: deps
-	cp -pv $(TARGET_OBJ:%=$(FROM)/%) .
-	date -Iseconds >.version
-	$(SUDO) docker build -t $(REPO):$(TAG) .
+version:
+	@echo "$(RELEASE_VERSION)" | tee .version
 
-push:	build
-	$(SUDO) docker push $(REPO):$(TAG)
+build: deps version
+	cp -pv $(TARGET_OBJ:%=$(FROM)/%) .
+	@echo $(FQIN) >dockertag
+	$(SUDO) docker build -q -t $$(cat dockertag) .
+
+push:
+	(dockertag=$$(cat dockertag); echo pushing $$dockertag; $(SUDO) docker push $$dockertag)
+
+# would be nice to validate that the image contains .version that matches what's in the dir
+promote:
+	echo $(REPO):$(DCOS_PREFIX)-$$(cat .version) >dockertag
+	(dockertag=$$(cat dockertag); echo promoting $$dockertag; $(SUDO) docker tag -f $(REPO):$(DCOS_PREFIX)-dev $$dockertag) && \
+	$(MAKE) push
+
+release:
+	$(MAKE) build push FROM=$(FROM) RELEASE=$(RELEASE)
 
 s6:
 	mkdir -pv _build/s6 _build/dist && chmod -v o+rw _build/dist

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -21,6 +21,10 @@ mesos-dns servers may be used as fallbacks for name resolution since their IP ad
 ## promote the latest -dev build to a version-tagged release
 ## (don't forget to update the universe config.json/version and package.json/docker-image)
 :; make promote
+
+## HOWEVER, to generate a fresh release image and push it up (skip the -dev tag cycle):
+## (this is probably an exceptional case, images should usually be promoted from -dev)
+:; make release FROM=~/bin RELEASE=1
 ```
 
 ## Files

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -16,8 +16,13 @@ mesos-dns servers may be used as fallbacks for name resolution since their IP ad
 ## Usage
 ```
 ## build and push the docker image
-:; make push TARGET=$HOME/bin/km
+:; make release FROM=/k8sm-build-output-dir
+
+## promote the latest -dev build to a version-tagged release
+## (don't forget to update the universe config.json/version and package.json/docker-image)
+:; make promote
 ```
+
 ## Files
 * Makefile - coordinate the build process: build s6, bundle it with km into a Docker and push the repo
 * Dockerfile - recipe for building the docker


### PR DESCRIPTION
- improvements to the dcos image release process
  - can still build & push -dev images easily for testing
  - can promote latest -dev build image to release-tagged via `promote` target
- bug fixes for service dependency mgmt