### PR TITLE
Add docker & docker-compose scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 # Folders
 _obj
 _test
-bin
+/bin
 _build
 
 # Architecture specific extensions/prefixes

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,113 @@
+# Running Kubernetes-Mesos In Docker
+
+There are several ways to play with kubernetes-mesos in docker. Here are a couple that might be most useful:
+
+1. [Complete](#complete)
+  - Run components and dependencies all in the same container
+  - All containers mirroring localhost ports (docker host mode)
+2. [Composed](#composed)
+  - Run components and dependencies each in different containers
+  - Each container gets its own IP
+  - Requires an ambassador to proxy ports (docker doesn't allow circular hostname linking)
+  - Emulates a more complex system, useful for testing networking
+
+While it is technically possible to run docker within a docker container, doing so requires running the mesos (slave) in priveledged mode.
+Instead, it's easier to mount the docker socket (`-v "/var/run/docker.sock:/var/run/docker.sock"`) and give mesos access to the docker it's running in.
+
+In addition to running in docker, it's also possible to [run docker locally](#local).
+
+<a name="complete"/>
+## K8SM Complete
+
+The "complete" Dockerfile includes everything needed to run a development instance of kubernetes-mesos, including etcd and mesos.
+
+### Daemon mode
+
+```
+docker run -d --name kubernetes-mesos -p 8888:8888 -p 5050:5050 -p 4001:4001 -v "/var/run/docker.sock:/var/run/docker.sock" mesosphere/kubernetes-mesos-complete
+```
+
+To see the logs:
+
+```
+docker logs kubernetes-mesos
+```
+
+To attach in interactive mode to a container already running in daemon mode:
+
+```
+docker exec -it kubernetes-mesos /bin/bash
+```
+
+### Interactive mode
+
+```
+docker run -it --name kubernetes-mesos -p 8888:8888 -p 5050:5050 -p 4001:4001 -v "/var/run/docker.sock:/var/run/docker.sock" --entrypoint=/bin/bash mesosphere/kubernetes-mesos-complete
+```
+
+Note: Interactive mode launches bash instead of the start script.
+
+### Stopping
+
+```
+docker kill kubernetes-mesos
+```
+
+### Building
+
+```
+./docker/complete/build.sh
+```
+
+
+<a name="composed"/>
+## K8SM Composed
+
+This method requires [Docker Compose](https://docs.docker.com/compose/) to be installed, which can be done via apt-get, homebrew, or [manually](https://docs.docker.com/compose/install/).
+
+The provided docker-compose.yml contains a self-contained configuration for running kubernetes-mesos, including its dependencies (etcd & mesos).
+It will launch 5 docker containers linked together with hostnames and port forwarding.
+
+```
+# from inside the docker dir
+docker-compose up
+```
+
+This will tail all the logs for each of the containers into STDOUT. `ctrl-c` to exit.
+
+### Stopping
+
+```
+docker-compose rm
+```
+
+### Building
+
+The docker-compose.yml file references multiple different docker images.
+
+The one that contains just kubernetes-mesos (not mesos or etcd) can be built with the following:
+
+```
+./docker/km/build.sh
+```
+
+
+<a name="local"/>
+## K8SM Local
+
+Since kubernetes-mesos requires etcd, mesos, and docker, these can all be started at once or individually.
+
+To start etcd, mesos, and kubernetes-mesos to run locally use the following command:
+
+```
+$ ./docker/bin/km-complete
+```
+
+If you already have etcd and mesos running locally use the following to start just the three kubernetes-mesos components:
+
+```
+$ ./docker/bin/km-local
+```
+
+Notes:
+- The mesos slave (which runs the kubernetes-mesos executor) needs docker to be installed (or configured via tcp). By default it talks to it using the socket `/var/run/docker.sock`.

--- a/docker/bin/await-connection
+++ b/docker/bin/await-connection
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Wait for a service to accept connections.
+# Block up to the max wait time (default: 10 seconds).
+# Usage: await-connection [-t=<duration>] <ip> <port>
+
+set -e
+
+duration=10
+if [[ "$1" == "-t="* ]]; then
+    duration="${1:3}"
+    [ -z "$duration" ] && echo "Invalid duration supplied" && exit 1
+    shift
+fi
+
+ip=$1
+port=$2
+[ -z "$ip" ] && echo "No IP supplied" && exit 1
+[ -z "$port" ] && echo "No port supplied" && exit 1
+
+# add the current dir to PATH
+bin=$(cd $(dirname $0) && pwd -P)
+export PATH=$PATH:${bin}
+
+echo "Waiting (up to ${duration}s) for ${ip}:${port} to accept connections"
+if ! timeout ${duration} bash -c "while ! echo exit | nc -z $ip $port; do sleep 0.5; done"; then
+    echo "Timed out"
+    exit 1
+fi

--- a/docker/bin/await-health-check
+++ b/docker/bin/await-health-check
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Wait for a service to accept connections.
+# Block up to the timeout duration in seconds (default: 10).
+# Usage: await-health-check [-t=<duration>] <address>
+
+set -e
+
+duration=10
+if [[ "$1" == "-t="* ]]; then
+    duration="${1:3}"
+    [ -z "$duration" ] && echo "Invalid duration supplied" && exit 1
+    shift
+fi
+
+address=$1
+[ -z "$address" ] && echo "No address supplied" && exit 1
+
+# add the current dir to PATH
+bin=$(cd $(dirname $0) && pwd -P)
+export PATH=$PATH:${bin}
+
+echo "Waiting (up to ${duration}s) for ${address} to be healthy"
+if ! timeout ${duration} bash -c "while ! health-check ${address}; do sleep 0.5; done"; then
+    echo "Timed out"
+    exit 1
+fi
+
+echo "Health check of ${address} succeeded!"

--- a/docker/bin/cmd-exists
+++ b/docker/bin/cmd-exists
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Return true if the command(s) exists
+# Usage: cmd-exists [-q] <cmd> [cmd [cmd...]]
+# Flags:
+# -q - enabled quiet mode
+
+set -e
+
+QUIET=false
+if [ "$1" == "-q" ]; then
+    QUIET=true
+    shift
+fi
+
+cmd_name=$1
+[ -z "${cmd_name}" ] && echo "No command name supplied" && exit 1
+
+while [ ! -z ${cmd_name} ]; do
+    if ! type -p "${cmd_name}" &> /dev/null; then
+        [ ! ${QUIET} ] && echo "Command not found: ${cmd_name}"
+        exit 127
+    fi
+
+    shift
+    cmd_name=$1
+done

--- a/docker/bin/health-check
+++ b/docker/bin/health-check
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Curl an endpoint and expect it to respond with status 200.
+# Usage: health-check <address>
+
+set -e
+
+address=$1
+[ -z "$address" ] && echo "No address supplied" && exit 1
+
+status=$(curl -s -o /dev/null -w '%{http_code}' ${address})
+if [[ ${status} == '200' ]]; then
+    exit 0
+fi
+if [[ ${status} == '000' ]]; then
+    exit 7
+fi
+
+exit 1

--- a/docker/bin/install-etcd.sh
+++ b/docker/bin/install-etcd.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+ETCD_ARCHIVE_URL=${ETCD_ARCHIVE_URL:-https://github.com/coreos/etcd/releases/download/v0.4.6/etcd-v0.4.6-linux-amd64.tar.gz}
+ETCD_ARCHIVE=/tmp/$(basename ${ETCD_ARCHIVE_URL})
+
+echo "Downloading etcd (${ETCD_ARCHIVE_URL})..."
+wget -q $ETCD_ARCHIVE_URL -O $ETCD_ARCHIVE
+echo "Installing etcd (/usr/local/bin/etcd)..."
+mkdir -p /tmp/etcd
+tar xf $ETCD_ARCHIVE -C /tmp/etcd
+mv /tmp/etcd/*/etcd* /usr/local/bin/
+
+rm -f $ETCD_ARCHIVE

--- a/docker/bin/install-go.sh
+++ b/docker/bin/install-go.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+GOPATH=${GOPATH:-~/go}
+GO_ARCHIVE_URL=${GO_ARCHIVE_URL:-https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz}
+GO_ARCHIVE=/tmp/$(basename ${GO_ARCHIVE_URL})
+
+echo "Downloading go (${GO_ARCHIVE_URL})..."
+mkdir -p $(dirname $GOROOT)
+wget -q $GO_ARCHIVE_URL -O $GO_ARCHIVE
+echo "Installing go (${GOROOT})..."
+tar xf $GO_ARCHIVE -C $(dirname $GOROOT)
+
+if [ ! -d $TMPDIR ]; then
+    mkdir -p $TMPDIR
+fi
+
+rm -f $GO_ARCHIVE

--- a/docker/bin/km-complete
+++ b/docker/bin/km-complete
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Run etcd, mesos-local, km apiserver, km controller-manager, and km scheduler.
+# Exiting (or failure of) this script will cause the above sub-processes to be killed.
+# Usage: km-local
+# Mac support requires gtimeout & pcregrep (brew install coreutils && brew install pcre)
+# Inputs:
+# PUBLIC_IP - IP the etcd, mesos, and km components will listen on (unless overridden by MESOS_IP or ETCD_IP)
+# MESOS_IP - IP that mesos is accessible on
+# MESOS_PORT - Port that mesos-master is accessible on (default 5050)
+# ETCD_IP - IP that etcd is accessible on
+# ETCD_PORT - Port that etcd is accessible on (default 4001)
+# LOG_DIR - Directory to write logs to (default /tmp/k8sm-logs)
+
+set -e
+
+# add the current dir to PATH
+bin=$(cd $(dirname $0) && pwd -P)
+export PATH=$PATH:${bin}
+
+# add kubernetes-mesos/bin to PATH (unless km-local has been moved)
+k8sm_bin=$(cd ${bin}/../../bin && pwd -P)
+[ -d "$k8sm_bin" ] && [ -e "${k8sm_bin}/km" ] && export PATH=$PATH:${k8sm_bin} || true
+
+# validate required scripts & binaries
+cmd-exists "await-connection" "etcd" "mesos-local" "km-local" "publicip"
+
+PUBLIC_IP=$(publicip)
+
+set -e
+
+#TODO(karl): use mesos defaults & auto-detect ip/port from local mesos process
+export MESOS_IP=${PUBLIC_IP}
+export MESOS_PORT=5050
+export MESOS_MASTER=${MESOS_IP}:${MESOS_PORT}
+echo "Mesos: ${MESOS_MASTER}"
+
+#TODO(karl): use etcd defaults & auto-detect ip/port from local etcd process
+export ETCD_IP=${PUBLIC_IP}
+export ETCD_PORT=4001
+export ETCD_URL=http://${ETCD_IP}:${ETCD_PORT}
+echo "Etcd: ${ETCD_URL}"
+
+LOG_DIR=${LOG_DIR:-"/tmp/k8sm-logs"}
+mkdir -p ${LOG_DIR}
+echo "Log Dir: ${LOG_DIR}"
+
+echo "---------------------"
+
+
+source ${bin}/subprocs.sh
+
+# propagate SIGINT & SIGTERM
+for sig in INT TERM EXIT; do
+    trap "kill_subprocs ${sig}" ${sig}
+done
+
+
+echo "Starting etcd &> ${LOG_DIR}/etcd.log"
+etcd \
+  -addr=${ETCD_IP}:${ETCD_PORT} \
+  &> ${LOG_DIR}/etcd.log \
+  &
+add_subproc "$!" "etcd"
+#await-connection ${ETCD_IP} ${ETCD_PORT}
+await-health-check ${ETCD_URL}/health
+echo "---------------------"
+
+
+echo "Starting mesos-local ${LOG_DIR}/mesos.log"
+mesos-local \
+  &> ${LOG_DIR}/mesos.log \
+  &
+add_subproc "$!" "mesos-local"
+#await-connection ${MESOS_IP} ${MESOS_PORT}
+await-health-check http://${MESOS_MASTER}/health
+echo "---------------------"
+
+
+echo "Starting km-local"
+km-local &
+add_subproc "$!" "km-local"
+echo "---------------------"
+
+
+await_subprocs

--- a/docker/bin/km-local
+++ b/docker/bin/km-local
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+# Run etcd, mesos-local, km apiserver, km controller-manager, and km scheduler.
+# Exiting (or failure of) this script will cause the above sub-processes to be killed.
+# Usage: km-local
+# Mac support requires gtimeout & pcregrep (brew install coreutils && brew install pcre)
+# Inputs:
+# PUBLIC_IP - IP the km components will listen on
+# MESOS_IP - IP that mesos is accessible on
+# MESOS_PORT - Port that mesos-master is accessible on (default 5050)
+# ETCD_IP - IP that etcd is accessible on
+# ETCD_PORT - Port that etcd is accessible on (default 4001)
+# LOG_DIR - Directory to write logs to (default /tmp/k8sm-logs)
+
+set -e
+
+# add the current dir to PATH
+bin=$(cd $(dirname $0) && pwd -P)
+export PATH=$PATH:${bin}
+
+# validate required scripts
+cmd-exists "await-connection"
+
+# add kubernetes-mesos/bin to PATH (unless km-local has been moved)
+k8sm_bin=$(cd ${bin}/../../bin && pwd -P)
+[ -d "$k8sm_bin" ] && [ -e "${k8sm_bin}/km" ] && export PATH=$PATH:${k8sm_bin} || true
+
+# validate required binaries
+cmd-exists "km"
+
+PUBLIC_IP=$(publicip)
+
+set -e
+
+export K8SM_IP=${PUBLIC_IP}
+export K8SM_PORT=8888
+echo "Kubernetes: ${K8SM_IP}:${K8SM_PORT}"
+
+#TODO(karl): auto-detect ip/port from local mesos process
+export MESOS_IP=${MESOS_IP:-$PUBLIC_IP}
+export MESOS_PORT=${MESOS_PORT:-5050}
+export MESOS_MASTER=${MESOS_IP}:${MESOS_PORT}
+echo "Mesos: ${MESOS_MASTER}"
+
+#TODO(karl): auto-detect ip/port from local etcd process
+export ETCD_IP=${ETCD_IP:-$PUBLIC_IP}
+export ETCD_PORT=${ETCD_PORT:-4001}
+export ETCD_URL=http://${ETCD_IP}:${ETCD_PORT}
+echo "Etcd: ${ETCD_URL}"
+
+
+K8SM_CONFIG="$(pwd)/mesos-cloud.conf"
+echo "Config: ${K8SM_CONFIG}"
+if [ ! -f "$K8SM_CONFIG" ]; then
+    echo "Writing default config"
+    echo "[mesos-cloud]
+        http-client-timeout = 5s
+        state-cache-ttl     = 20s
+    " > ${K8SM_CONFIG}
+fi
+
+LOG_DIR=${LOG_DIR:-"/tmp/k8sm-logs"}
+mkdir -p ${LOG_DIR}
+echo "Log Dir: ${LOG_DIR}"
+
+echo "---------------------"
+
+
+source ${bin}/subprocs.sh
+
+# propagate SIGINT & SIGTERM
+for sig in INT TERM EXIT; do
+    trap "kill_subprocs ${sig}" ${sig}
+done
+
+echo "Detecting etcd"
+#await-connection ${ETCD_IP} ${ETCD_PORT}
+await-health-check ${ETCD_URL}/health
+echo "---------------------"
+
+
+echo "Detecting mesos-master"
+#await-connection ${MESOS_IP} ${MESOS_PORT}
+await-health-check http://${MESOS_MASTER}/health
+echo "---------------------"
+
+echo "Starting km apiserver &> ${LOG_DIR}/apiserver.log"
+km apiserver \
+  --address=${K8SM_IP} \
+  --etcd_servers=${ETCD_URL} \
+  --portal_net=10.10.10.0/24 \
+  --port=${K8SM_PORT} \
+  --cloud_provider=mesos \
+  --cloud_config=${K8SM_CONFIG} \
+  &> ${LOG_DIR}/apiserver.log \
+  &
+add_subproc "$!" "km apiserver"
+#await-connection "${K8SM_IP}" ${K8SM_PORT}
+await-health-check http://${K8SM_IP}:${K8SM_PORT}/healthz
+echo "---------------------"
+
+
+echo "Starting km controller-manager &> ${LOG_DIR}/controller-manager.log"
+km controller-manager \
+  --master=${K8SM_IP}:${K8SM_PORT} \
+  --cloud_config=${K8SM_CONFIG} \
+  &> ${LOG_DIR}/controller-manager.log \
+  &
+add_subproc "$!" "km controller-manager"
+echo "---------------------"
+
+
+echo "Starting km scheduler &> ${LOG_DIR}/scheduler.log"
+km scheduler \
+  --mesos_master=${MESOS_MASTER} \
+  --address=${K8SM_IP} \
+  --etcd_servers=${ETCD_URL} \
+  --mesos_user=root \
+  --api_servers=${K8SM_IP}:${K8SM_PORT} \
+  &> ${LOG_DIR}/scheduler.log \
+  &
+add_subproc "$!" "km scheduler"
+echo "---------------------"
+
+
+await_subprocs

--- a/docker/bin/publicip
+++ b/docker/bin/publicip
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "${PUBLIC_IP}" ]; then
+    if cmd-exists "ifconfig" && cmd-exists "ipconfig" && cmd-exists "pcregrep"; then
+        PUBLIC_IP=$(ifconfig | pcregrep -M -o '^[^\t:]+:([^\n]|\n\t)*status: active' | egrep -o -m 1 '^[^\t:]+' | xargs ipconfig getifaddr)
+    fi
+    if [ -z "${PUBLIC_IP}" ] && cmd-exists "ip"; then
+        PUBLIC_IP=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
+    fi
+    if [ -z "${PUBLIC_IP}" ]; then
+        PUBLIC_IP="0.0.0.0"
+    fi
+fi
+
+echo ${PUBLIC_IP}

--- a/docker/bin/resolveip
+++ b/docker/bin/resolveip
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Resolve an IP from a hostname (using getent)
+# Usage: resolveip <hostname>
+
+set -e
+
+hostname=$1
+[ -z "$hostname" ] && echo "No hostname supplied" && exit 1
+
+#TODO(karl): Mac support
+getent hosts $hostname | cut -d' ' -f1 | sort -u | tail -1

--- a/docker/bin/subprocs.sh
+++ b/docker/bin/subprocs.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+SUBPROCS=()
+SUBPROC_NAMES=()
+
+# Add the pid of a sub-process or return 1 if it is not running
+add_subproc () {
+    local SUBPROC=$1
+    local SUBPROC_NAME="$2"
+    echo "Started ${SUBPROC_NAME} (${SUBPROC})"
+    if ! ps aux | grep -v grep | grep "${SUBPROC_NAME}" &> /dev/null; then
+        echo "Failed to start ${SUBPROC_NAME}"
+        return 1
+    fi
+#    echo "Running ${SUBPROC_NAME} (${SUBPROC})"
+    SUBPROCS+=(${SUBPROC})
+    SUBPROC_NAME=${SUBPROC_NAME// /_} # replace spaces with underscores (bash arrays are space deliniated)
+    SUBPROC_NAMES+=(${SUBPROC_NAME})
+}
+
+# Kill subprocesses in reverse order of being started (to avoid log spam)
+kill_subprocs () {
+    SIGNAL=$1
+    echo "Shutting down [km-complete] (Signal: ${SIGNAL})"
+    if [ ! -z "${SUBPROCS}" ]; then
+        for ((i=${#SUBPROCS[@]}-1; i>=0; i--)); do
+            local SUBPROC=${SUBPROCS[i]}
+            local SUBPROC_NAME=${SUBPROC_NAMES[i]}
+            local SUBPROC_NAME=${SUBPROC_NAME//_/ } # replace underscores with spaces
+            if pid_running "${SUBPROC}"; then
+                echo "Killing ${SUBPROC_NAME} (${SUBPROC})"
+                #TODO(karl): propagate the recieved signal, instead of just TERM
+                kill ${SUBPROC} || true
+            fi
+        done
+    fi
+    if [ "${SIGNAL}" != "EXIT" ]; then
+        # Disable exit trap if we already killed everything in INT/TERM
+        trap EXIT
+    fi
+}
+
+# Check if a process ID is running
+pid_running () {
+    local CMD_PID=$1
+    return $(kill -0 ${CMD_PID} &> /dev/null)
+}
+
+# Block until all subprocs have exited
+await_subprocs () {
+    for subproc in "${SUBPROCS[@]}"; do
+        if pid_running "${subproc}"; then
+            echo "Waiting on ${subproc}"
+            wait ${subproc}
+        fi
+    done
+}

--- a/docker/bin/timeout
+++ b/docker/bin/timeout
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Wrapper around GNU timeout to support Mac Homebrew installation as gtimeout
+
+set -e
+
+# add the current dir to PATH
+bin=$(cd $(dirname $0) && pwd -P)
+
+# find command named 'timeout' that isn't this file
+while read -r cmd_path; do
+    if [ "${cmd_path}" != "${bin}/timeout" ]; then
+        TIMEOUT="${cmd_path}"
+        break
+    fi
+done <<< "$(which -a timeout)"
+
+if [ -z  ${TIMEOUT} ]; then
+    TIMEOUT=$(which gtimeout)
+    if [ -z  ${TIMEOUT} ]; then
+        echo "timeout or gtimeout command not found"
+        exit 1
+    fi
+fi
+
+exec ${TIMEOUT} "$@"

--- a/docker/complete/Dockerfile
+++ b/docker/complete/Dockerfile
@@ -1,0 +1,28 @@
+FROM mesosphere/mesos:0.22.0-1.0.ubuntu1404
+MAINTAINER Mesosphere <support@mesosphere.io>
+
+RUN locale-gen en_US.UTF-8
+RUN dpkg-reconfigure locales
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        wget \
+        curl \
+        && \
+    apt-get clean
+
+RUN mkdir /kubernetes-mesos
+WORKDIR /kubernetes-mesos
+
+COPY ./bin /kubernetes-mesos/bin
+COPY ./docker/bin/* /kubernetes-mesos/bin/
+ENV PATH /kubernetes-mesos/bin:$PATH
+
+ADD ./docker/mesos-cloud.conf /opt/
+
+RUN install-etcd.sh && which install-etcd.sh | xargs rm
+
+EXPOSE 8888 5050 4001
+ENTRYPOINT ["km-complete"]

--- a/docker/complete/build.sh
+++ b/docker/complete/build.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+EXPECTED_SCRIPT_DIR=docker/complete
+EXPECTED_BINARY_DIR=bin
+
+set -ex
+
+script_dir=$(cd $(dirname $0) && pwd -P)
+
+# defence against lazy refactoring
+[[ "$script_dir" != *"$EXPECTED_SCRIPT_DIR" ]] && echo "Build script has moved! Expected location: $EXPECTED_SCRIPT_DIR" && exit 1
+
+project_dir=$(cd "${script_dir}/../.." && pwd -P)
+cd ${project_dir}
+
+# create temp dir in project dir to avoid permission issues
+WORKSPACE=$(env TMPDIR=$PWD mktemp -d -t "k8sm-workspace")
+echo "Workspace created: $WORKSPACE"
+
+cleanup() {
+    rm -rf ${WORKSPACE}
+    echo "Workspace deleted: $WORKSPACE"
+}
+trap 'cleanup' EXIT
+
+mkdir ${WORKSPACE}/bin
+
+echo "Building kubernetes-mesos binaries"
+docker run --rm -v ${WORKSPACE}/bin:/target mesosphere/kubernetes-mesos:build
+
+echo "Binaries produced:"
+ls ${WORKSPACE}/bin
+
+[ ! -e ${WORKSPACE}/bin/km ] && echo "Binaries not produced...?" && exit 1
+
+# setup workspace to mirror project dir (for resources required by the dockerfile)
+echo "Setting up workspace"
+mkdir -p ${WORKSPACE}/docker/bin
+cp ${project_dir}/docker/bin/* ${WORKSPACE}/docker/bin/
+cp ${project_dir}/docker/mesos-cloud.conf ${WORKSPACE}/docker/
+
+# Dockerfile must be within build context
+cp ${project_dir}/${EXPECTED_SCRIPT_DIR}/Dockerfile ${WORKSPACE}/
+
+cd ${WORKSPACE}
+
+# build docker image
+echo "Building kubernetes-mesos-complete docker image"
+docker build -t mesosphere/kubernetes-mesos-complete .

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,102 @@
+ambassador:
+  image: cpuguy83/docker-grand-ambassador:0.9.1
+  volumes:
+  - /var/run/docker.sock:/var/run/docker.sock
+  command: "-name docker_apiserver_1"
+etcd:
+  hostname: etcd
+  image: quay.io/coreos/etcd:v2.0.10
+  ports: [ "4001:4001" ]
+  command: >
+    --listen-client-urls 'http://etcd:4001'
+    --advertise-client-urls 'http://etcd:4001'
+#zookeeper:
+#  image: jplock/zookeeper:3.4.5
+#  ports: [ "2181:2181" ]
+mesos:
+  hostname: mesos
+  image: mesosphere/mesos:0.22.0-1.0.ubuntu1404
+  entrypoint: mesos-local
+  ports: [ "5050:5050" ]
+  environment:
+  - MESOS_HOSTNAME=mesos
+  - MESOS_PORT=5050
+  - MESOS_LOG_DIR=/var/log/mesos
+  - MESOS_QUORUM=1
+  - MESOS_REGISTRY=in_memory
+  - MESOS_WORK_DIR=/var/lib/mesos
+#  - MESOS_ZK=zk://zookeeper:2181/mesos
+  links:
+  - etcd
+  - "ambassador:apiserver"
+  volumes:
+  - /var/run/docker.sock:/var/run/docker.sock
+#  - zookeeper
+apiserver:
+  hostname: apiserver
+  image: mesosphere/kubernetes-mesos:latest
+  entrypoint:
+  - /bin/bash
+  - "-c"
+  - >
+    echo "Hostname: $(hostname -f) ($(hostname -f | xargs resolveip))" &&
+    (grep "mesos-master\s*=" /opt/mesos-cloud.conf || echo "  mesos-master = mesos:5050" >> /opt/mesos-cloud.conf) &&
+    await-health-check http://etcd:4001/health &&
+    await-health-check http://mesos:5050/health &&
+    km apiserver
+    --address=$(resolveip apiserver)
+    --external_hostname=apiserver
+    --etcd_servers=http://etcd:4001
+    --portal_net=10.10.10.0/24
+    --port=8888
+    --cloud_provider=mesos
+    --cloud_config=/opt/mesos-cloud.conf
+    --v=2
+  ports: [ "8888:8888" ]
+  links:
+  - etcd
+  - mesos
+controller:
+  hostname: controller
+  image: mesosphere/kubernetes-mesos:latest
+  entrypoint:
+  - /bin/bash
+  - "-c"
+  - >
+    echo "Hostname: $(hostname -f) ($(hostname -f | xargs resolveip))" &&
+    (grep "mesos-master\s*=" /opt/mesos-cloud.conf || echo "  mesos-master = mesos:5050" >> /opt/mesos-cloud.conf) &&
+    await-health-check http://etcd:4001/health &&
+    await-health-check http://mesos:5050/health &&
+    await-health-check http://apiserver:8888/healthz &&
+    km controller-manager
+    --master=http://apiserver:8888
+    --cloud_config=/opt/mesos-cloud.conf
+    --v=2
+  links:
+  - etcd
+  - mesos
+  - apiserver
+scheduler:
+  hostname: scheduler
+  image: mesosphere/kubernetes-mesos:latest
+  entrypoint:
+  - /bin/bash
+  - "-c"
+  - >
+    echo "Hostname: $(hostname -f) ($(hostname -f | xargs resolveip))" &&
+    (grep "mesos-master\s*=" /opt/mesos-cloud.conf || echo "  mesos-master = mesos:5050" >> /opt/mesos-cloud.conf) &&
+    await-health-check http://etcd:4001/health &&
+    await-health-check http://mesos:5050/health &&
+    await-health-check http://apiserver:8888/healthz &&
+    km scheduler
+    --address=$(resolveip scheduler)
+    --hostname_override=scheduler
+    --etcd_servers=http://etcd:4001
+    --mesos_user=root
+    --api_servers=http://apiserver:8888
+    --mesos_master=mesos:5050
+    --v=2
+  links:
+  - etcd
+  - mesos
+  - apiserver

--- a/docker/km/Dockerfile
+++ b/docker/km/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:14.04.2
+MAINTAINER Mesosphere <support@mesosphere.io>
+
+RUN locale-gen en_US.UTF-8
+RUN dpkg-reconfigure locales
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        wget \
+        curl \
+        && \
+    apt-get clean
+
+RUN mkdir /kubernetes-mesos
+WORKDIR /kubernetes-mesos
+
+COPY ./bin /kubernetes-mesos/bin
+COPY ./docker/bin/* /kubernetes-mesos/bin/
+ENV PATH /kubernetes-mesos/bin:$PATH
+
+ADD ./docker/mesos-cloud.conf /opt/
+
+EXPOSE 8888
+ENTRYPOINT ["km-local"]

--- a/docker/km/build.sh
+++ b/docker/km/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# paths relative to project dir
+EXPECTED_SCRIPT_DIR=docker/km
+EXPECTED_BINARY_DIR=bin
+
+set -ex
+
+script_dir=$(cd $(dirname $0) && pwd -P)
+
+# defence against lazy refactoring
+[[ "$script_dir" != *"$EXPECTED_SCRIPT_DIR" ]] && echo "Build script has moved! Expected location: $EXPECTED_SCRIPT_DIR" && exit 1
+
+project_dir=$(cd "${script_dir}/../.." && pwd -P)
+cd ${project_dir}
+
+# create temp dir in project dir to avoid permission issues
+WORKSPACE=$(env TMPDIR=$PWD mktemp -d -t "k8sm-workspace")
+echo "Workspace created: $WORKSPACE"
+
+cleanup() {
+    rm -rf ${WORKSPACE}
+    echo "Workspace deleted: $WORKSPACE"
+}
+trap 'cleanup' EXIT
+
+mkdir ${WORKSPACE}/bin
+
+echo "Building kubernetes-mesos binaries"
+docker run --rm -v ${WORKSPACE}/bin:/target mesosphere/kubernetes-mesos:build
+
+echo "Binaries produced:"
+ls ${WORKSPACE}/bin
+
+[ ! -e ${WORKSPACE}/bin/km ] && echo "Binaries not produced...?" && exit 1
+
+# setup workspace to mirror project dir (for resources required by the dockerfile)
+echo "Setting up workspace"
+mkdir -p ${WORKSPACE}/docker/bin
+cp ${project_dir}/docker/bin/* ${WORKSPACE}/docker/bin/
+cp ${project_dir}/docker/mesos-cloud.conf ${WORKSPACE}/docker/
+
+# Dockerfile must be within build context
+cp ${project_dir}/${EXPECTED_SCRIPT_DIR}/Dockerfile ${WORKSPACE}/
+
+cd ${WORKSPACE}
+
+# build docker image
+echo "Building kubernetes-mesos docker image"
+docker build -t mesosphere/kubernetes-mesos .

--- a/docker/mesos-cloud.conf
+++ b/docker/mesos-cloud.conf
@@ -1,0 +1,3 @@
+[mesos-cloud]
+  http-client-timeout = 5s
+  state-cache-ttl     = 20s

--- a/pkg/scheduler/service/publish.go
+++ b/pkg/scheduler/service/publish.go
@@ -110,7 +110,7 @@ func (m *SchedulerServer) setEndpoints(serviceName string, ip net.IP, port int) 
 	}
 	if !reflect.DeepEqual(e.Subsets, want) {
 		e.Subsets = want
-		glog.Infof("setting endpoints for master service %q to %+v", serviceName, e)
+		glog.Infof("setting endpoints for master service %q to %#v", serviceName, e)
 		_, err = createOrUpdate(e)
 		return err
 	}

--- a/pkg/scheduler/service/service.go
+++ b/pkg/scheduler/service/service.go
@@ -395,10 +395,8 @@ func (s *SchedulerServer) createAPIServerClient() (*client.Client, error) {
 	return c, nil
 }
 
-func (s *SchedulerServer) setDriver(driver bindings.SchedulerDriver, err error) {
-	if err == nil {
-		s.driver.Store(driver)
-	}
+func (s *SchedulerServer) setDriver(driver bindings.SchedulerDriver) {
+	s.driver.Store(driver)
 }
 
 func (s *SchedulerServer) getDriver() (driver bindings.SchedulerDriver) {
@@ -596,26 +594,29 @@ func (s *SchedulerServer) bootstrap(hks hyperkube.Interface, sc *schedcfg.Config
 	runtime.On(mesosPodScheduler.Registration(), func() { kpl.Run(schedulerProcess.Terminal()) })
 	runtime.On(mesosPodScheduler.Registration(), s.newServiceWriter(schedulerProcess.Terminal()))
 
-	deferredInit := func() (err error) {
-		if err = mesosPodScheduler.Init(schedulerProcess.Master(), kpl, s.mux); err != nil {
-			err = fmt.Errorf("failed to initialize pod scheduler: %v", err)
-		}
-		return
-	}
-
-	driverFactory := ha.DriverFactory(func() (drv bindings.SchedulerDriver, err error) {
+	driverFactory := ha.DriverFactory(func() (bindings.SchedulerDriver, error) {
 		log.V(1).Infoln("performing deferred initialization")
-		if err = deferredInit(); err == nil {
-			log.V(1).Infoln("deferred init complete")
-			// defer obtaining framework ID to prevent multiple schedulers
-			// from overwriting each other's framework IDs
-			if dconfig.Framework.Id, err = s.fetchFrameworkID(etcdClient); err == nil {
-				log.V(1).Infoln("instantiating mesos scheduler driver")
-				drv, err = bindings.NewMesosSchedulerDriver(*dconfig)
-				s.setDriver(drv, err)
-			}
+		if err = mesosPodScheduler.Init(schedulerProcess.Master(), kpl, s.mux); err != nil {
+			return nil, fmt.Errorf("failed to initialize pod scheduler: %v", err)
 		}
-		return
+		log.V(1).Infoln("deferred init complete")
+
+		// defer obtaining framework ID to prevent multiple schedulers
+		// from overwriting each other's framework IDs
+		dconfig.Framework.Id, err = s.fetchFrameworkID(etcdClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch framework ID from etcd: %v", err)
+		}
+
+		log.V(1).Infoln("constructing mesos scheduler driver")
+		driver, err := bindings.NewMesosSchedulerDriver(*dconfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct scheduler driver: %v", err)
+		}
+		log.V(1).Infoln("constructed mesos scheduler driver:", driver)
+
+		s.setDriver(driver)
+		return driver, nil
 	})
 
 	return schedulerProcess, driverFactory, etcdClient, eid


### PR DESCRIPTION
This PR includes several pieces:
- A dockerfile for creating mesosphere/kubernetes-mesos-complete with all dependencies
- A dockerfile for creating mesosphere/kubernetes-mesos without dependencies
- A docker-compose file to run k8sm and each of its dependencies in separate containers
- Several scripts:
  - km-complete for running k8sm with dependencies
  - km-local for running k8sm without dependencies
  - helper scripts: await-service, cmd-exists, publicip, resolveip
- A readme for using the above

I figure these are useful on their own without the integration tests that prompted their creation. So I'm making the integration tests a different PR.