### PR TITLE
Fixes skydns failure on Kubernetes master container failure and recovery to a different node.

### DIFF
--- a/hack/images/dcos/bootstrap.sh
+++ b/hack/images/dcos/bootstrap.sh
@@ -121,7 +121,7 @@ cat <<EOF >${cloud_config}
 EOF
 
 # address of the apiserver
-kube_master="http://${host_ip}:${apiserver_port}"
+kube_master="http://${apiserver_host}:${apiserver_port}"
 
 #
 # create services directories and scripts


### PR DESCRIPTION
$kube_master should reference the apiserver_host variable rather than relying on the $host_ip var which is hardcoded and causes kubedns to fail when the Kubernetes master changes nodes/IP's due to failure/reboot/etc...

When the Kubernetes master changes nodes due to host node failure, but kubedns is still available, the kube2sky container will throw the following errors because it has the old Kubernetes IP.

```
E0729 20:10:47.424239       1 reflector.go:136] Failed to list *api.Service: Get http://10.11.3.148:25502/api/v1/services: dial tcp 10.11.3.148:25502: no route to host
E0729 20:10:50.430182       1 reflector.go:136] Failed to list *api.Service: Get http://10.11.3.148:25502/api/v1/services: dial tcp 10.11.3.148:25502: no route to host
E0729 20:10:50.430254       1 reflector.go:136] Failed to list *api.Endpoints: Get http://10.11.3.148:25502/api/v1/endpoints: dial tcp 10.11.3.148:25502: no route to host
E0729 20:10:53.436152       1 reflector.go:136] Failed to list *api.Endpoints: Get http://10.11.3.148:25502/api/v1/endpoints: dial tcp 10.11.3.148:25502: no route to host
E0729 20:10:53.436218       1 reflector.go:136] Failed to list *api.Service: Get http://10.11.3.148:25502/api/v1/services: dial tcp 10.11.3.148:25502: no route to host
E0729 20:10:56.442187       1 reflector.go:136] Failed to list *api.Service: Get http://10.11.3.148:25502/api/v1/services: dial tcp 10.11.3.148:25502: no route to host
E0729 20:10:56.442254       1 reflector.go:136] Failed to list *api.Endpoints: Get http://10.11.3.148:25502/api/v1/endpoints: dial tcp 10.11.3.148:25502: no route to host
E0729 20:10:59.448127       1 reflector.go:136] Failed to list *api.Endpoints: Get http://10.11.3.148:25502/api/v1/endpoints: dial tcp 10.11.3.148:25502: no route to host
E0729 20:10:59.448192       1 reflector.go:136] Failed to list *api.Service: Get http://10.11.3.148:25502/api/v1/services: dial tcp 10.11.3.148:25502: no route to host
```