### PR TITLE
Cleanup of dcos package build process

### DIFF
--- a/hack/images/dcos/.dockerignore
+++ b/hack/images/dcos/.dockerignore
@@ -1,3 +1,3 @@
-_build
-etcd-v2.0.9-linux-amd64
-etcd-v2.0.9-linux-amd64.tar.gz
+_build/etcd-*
+_build/kubernetes
+

--- a/hack/images/dcos/.gitignore
+++ b/hack/images/dcos/.gitignore
@@ -1,10 +1,2 @@
-usr
-km
-etcd*
-.version
 dockertag
-kubectl
-skydns-rc.yaml.in
-skydns-svc.yaml.in
-kube-ui-rc.yaml
-kube-ui-svc.yaml
+_build

--- a/hack/images/dcos/.gitignore
+++ b/hack/images/dcos/.gitignore
@@ -1,2 +1,1 @@
-dockertag
 _build

--- a/hack/images/dcos/Dockerfile
+++ b/hack/images/dcos/Dockerfile
@@ -10,15 +10,16 @@ RUN echo 'nobody::99:' >>/etc/group
 CMD [ ]
 ENTRYPOINT [ "/opt/bootstrap.sh" ]
 
-ADD leapsecs.dat	/etc/
-ADD etcd		/opt/
-ADD etcdctl		/opt/
-ADD km			/opt/
-ADD kubectl		/opt/
-ADD skydns-rc.yaml.in	/opt/
-ADD skydns-svc.yaml.in	/opt/
-ADD kube-ui-rc.yaml	/opt/
-ADD kube-ui-svc.yaml	/opt/
-ADD functions.sh	/opt/
-ADD bootstrap.sh	/opt/
-ADD .version		/opt/
+ADD leapsecs.dat				/etc/
+ADD functions.sh				/opt/
+ADD bootstrap.sh				/opt/
+
+ADD _build/etcd					/opt/
+ADD _build/etcdctl				/opt/
+ADD _build/skydns-rc.yaml.in	/opt/
+ADD _build/skydns-svc.yaml.in	/opt/
+ADD _build/kube-ui-rc.yaml		/opt/
+ADD _build/kube-ui-svc.yaml		/opt/
+ADD _build/.version				/opt/
+ADD _build/km                   /opt/
+ADD _build/kubectl              /opt/

--- a/hack/images/dcos/Dockerfile
+++ b/hack/images/dcos/Dockerfile
@@ -1,14 +1,7 @@
 FROM busybox:ubuntu-14.04
 MAINTAINER Mesosphere <support@mesosphere.com>
 
-ADD https://github.com/just-containers/s6-overlay/releases/download/v1.13.0.0/s6-overlay-amd64.tar.gz /tmp/
-RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && rm /tmp/s6-overlay-amd64.tar.gz
-
-RUN echo 'nobody:x:99:99:Nobody:/:/sbin/false' >>/etc/passwd
-RUN echo 'nobody::99:' >>/etc/group
-
-CMD [ ]
-ENTRYPOINT [ "/opt/bootstrap.sh" ]
+ADD _build/s6-overlay-amd64.tar.gz /
 
 ADD leapsecs.dat				/etc/
 ADD functions.sh				/opt/
@@ -23,3 +16,10 @@ ADD _build/kube-ui-svc.yaml		/opt/
 ADD _build/.version				/opt/
 ADD _build/km                   /opt/
 ADD _build/kubectl              /opt/
+
+RUN echo 'nobody:x:99:99:Nobody:/:/sbin/false' >>/etc/passwd
+RUN echo 'nobody::99:' >>/etc/group
+
+CMD []
+ENTRYPOINT [ "/opt/bootstrap.sh" ]
+

--- a/hack/images/dcos/Dockerfile
+++ b/hack/images/dcos/Dockerfile
@@ -3,19 +3,19 @@ MAINTAINER Mesosphere <support@mesosphere.com>
 
 ADD _build/s6-overlay-amd64.tar.gz /
 
-ADD leapsecs.dat				/etc/
-ADD functions.sh				/opt/
-ADD bootstrap.sh				/opt/
+ADD leapsecs.dat              /etc/
+ADD functions.sh              /opt/
+ADD bootstrap.sh              /opt/
 
-ADD _build/etcd					/opt/
-ADD _build/etcdctl				/opt/
-ADD _build/skydns-rc.yaml.in	/opt/
-ADD _build/skydns-svc.yaml.in	/opt/
-ADD _build/kube-ui-rc.yaml		/opt/
-ADD _build/kube-ui-svc.yaml		/opt/
-ADD _build/.version				/opt/
-ADD _build/km                   /opt/
-ADD _build/kubectl              /opt/
+ADD _build/etcd               /opt/
+ADD _build/etcdctl            /opt/
+ADD _build/skydns-rc.yaml.in  /opt/
+ADD _build/skydns-svc.yaml.in /opt/
+ADD _build/kube-ui-rc.yaml    /opt/
+ADD _build/kube-ui-svc.yaml   /opt/
+ADD _build/.version           /opt/
+ADD _build/km                 /opt/
+ADD _build/kubectl            /opt/
 
 RUN echo 'nobody:x:99:99:Nobody:/:/sbin/false' >>/etc/passwd
 RUN echo 'nobody::99:' >>/etc/group

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -18,12 +18,14 @@ VERSION := $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --alwa
 DOCKER_REPO = $(DOCKER_ORG)/kubernetes
 DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)
 
+# kubernetes binaries distributed in the Docker container
 K8S_BINARIES = km kubectl
 K8S_BINARIES_SOURCE_DIR = $(BUILD_DIR)/kubernetes/_output/dockerized/bin/$(1)/amd64
 K8S_BINARIES_SOURCE = $(addprefix $(call K8S_BINARIES_SOURCE_DIR,linux)/,$(K8S_BINARIES))
 K8S_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(K8S_BINARIES))
 KUBECTL_BINARIES = $(call K8S_BINARIES_SOURCE_DIR,linux)/kubectl $(call K8S_BINARIES_SOURCE_DIR,darwin)/kubectl
 
+# etcd distributed in the Docker container
 ETCD_IMAGE = etcd
 ETCD_TAG = 2.0.12
 ETCD_BINARIES = etcd etcdctl
@@ -31,11 +33,14 @@ ETCD_BINARIES_SOURCE_DIR = $(BUILD_DIR)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64
 ETCD_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(ETCD_BINARIES))
 ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
 
+# kubernetes addons: kube-dns and kube-ui
 KUBE_DNS_TEMPLATES = $(BUILD_DIR)/skydns-rc.yaml.in $(BUILD_DIR)/skydns-svc.yaml.in
 KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
 
+# github-release utility to upload release assets to Github
 GITHUB_RELEASE = $(shell pwd)/$(BUILD_DIR)/go/bin/github-release
 
+# meta targets
 .PHONY: clean build build_dir check_dirty clone test push deps version check_github_token release
 .INTERMEDIATE: build_kubernetes copy_kubernetes_binaries download_etcd
 
@@ -47,12 +52,14 @@ clean:
 build_dir:
 	@mkdir -p $(BUILD_DIR)
 
+# print out the version and create .version
 version: build_dir
 	@echo "GIT_REF=$(GIT_REF)"
 	@echo "VERSION=$(VERSION)"
 	@echo
 	@echo "$(VERSION)" > $(BUILD_DIR)/.version
 
+# clone the given kubernetes git ref
 clone: build_dir
 	@cd $(BUILD_DIR) && \
 	if [ ! -d "kubernetes" ]; then \
@@ -65,6 +72,7 @@ clone: build_dir
 		if [ "$$PREV" != "$$(git rev-parse HEAD)" ]; then touch ../rebuild; fi; \
 	fi
 
+# check that everything in the repo is commited
 check_dirty:
 	@cd $(BUILD_DIR)/kubernetes && \
 	if [ -n "$$(git status --porcelain)" ]; then \
@@ -72,19 +80,24 @@ check_dirty:
 		exit 1; \
 	fi
 
+# run the kubernetes unit and integration tests inside Docker
 test: clone
 	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-go.sh
 	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-integration.sh
 
+# cross-compile the kubernetes binaries inside Docker
 build_kubernetes: $(BUILD_DIR)/rebuild
 	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/build-cross.sh
 $(K8S_BINARIES_SOURCE): build_kubernetes
+$(KUBECTL_BINARIES): build_kubernetes
 
+# copy km and kubectl from the kubernetes _output directory to _build
 copy_kubernetes_binaries: $(K8S_BINARIES_SOURCE)
 	cp -pv $(K8S_BINARIES_SOURCE) $(BUILD_DIR)
 	touch $(K8S_BINARIES_DEST)
 $(K8S_BINARIES_DEST): copy_kubernetes_binaries
 
+# download etcd and extract it to _output/etcd-...
 download_etcd:
 	cd $(BUILD_DIR) && curl -L -O $(ETCD_SOURCE) && tar xzvf $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
 	cp -pv $(addprefix $(ETCD_BINARIES_SOURCE_DIR)/,$(ETCD_BINARIES)) $(BUILD_DIR)
@@ -97,28 +110,28 @@ $(KUBE_DNS_TEMPLATES):
 $(KUBE_UI_TEMPLATES):
 	curl -f $(GIT_REF_BASE_URL)/cluster/addons/kube-ui/$(shell basename $@) > $@
 
-$(BUILD_DIR):
-	mkdir -p $(BUILD_DIR)
+deps: build_dir $(ETCD_BINARIES_DEST) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
 
-deps: $(BUILD_DIR) $(ETCD_BINARIES_DEST) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
-
+# package build targets
 build: version clone check_dirty deps
 	docker build -q -t $(DOCKER_IMAGE) .
 	docker tag -f $(DOCKER_IMAGE) $(DOCKER_REPO):latest
 
+# push the Docker image to the Docker hub
 push:
 	echo pushing $(DOCKER_IMAGE); docker push $(DOCKER_IMAGE)
 
+# install github-release, a tool to upload github release assets
 $(GITHUB_RELEASE):
 	@mkdir -p $(BUILD_DIR)/go && \
 	export GOPATH=$$(pwd)/$(BUILD_DIR)/go && \
 	go get github.com/aktau/github-release
 
+# check that the environment variable GITHUB_TOKEN is set, needed to uploaded release assets
 check_github_token:
 	test -n "$$GITHUB_TOKEN"
 
-$(KUBECTL_BINARIES): build_kubernetes
-
+# upload the kubectl tar.gz for linux/amd64 and darwin/amd64 to github release given by GIT_REF
 release: $(GITHUB_RELEASE) check_github_token clone $(KUBECTL_BINARIES)
 	$(GITHUB_RELEASE) release -u mesosphere --repo kubernetes --tag $(GIT_REF) --name "Kubernetes on Mesos $(GIT_REF)" --draft
 	@set -x; for OS in linux darwin; do \

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -200,7 +200,7 @@ release: $(GITHUB_RELEASE) check_github_token $(KUBECTL_BINARIES)
 			echo && \
 			echo -n "Continue? [Y/n] " && read YES && if [ -n "$$YES" -a "$$YES" != Y -a "$$YES" != y ]; then exit 1; fi; \
 	fi
-	if $(GITHUB_RELEASE) info -u mesosphere --repo kubernetes --tag $(VERSION); then \
+	@if $(GITHUB_RELEASE) info -u mesosphere --repo kubernetes | grep -q $(VERSION); then \
 		echo "Found $(VERSION) release. Will edit." && RELEASE_COMMAND=edit; \
 	else \
 		echo "Creating $(VERSION) draft release"; \

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -206,7 +206,7 @@ release: $(GITHUB_RELEASE) check_github_token $(KUBECTL_BINARIES)
 		echo "Creating $(VERSION) draft release"; \
 	fi && \
 	$(GITHUB_RELEASE) $${RELEASE_COMMAND:-release} -u mesosphere --repo kubernetes --tag $(VERSION) --name "Kubernetes on Mesos $(VERSION)" --draft
-	@set -x; for OS in linux darwin; do \
+	@for OS in linux darwin; do \
 		BUILD_DIR=$$PWD/$(BUILD_DIR) && \
 		cd $(call K8S_BINARIES_SOURCE_DIR,$$OS) && \
 		TAR=kubectl-$(VERSION)-$$OS-amd64.tgz && \

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -33,8 +33,8 @@ ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ET
 KUBE_DNS_TEMPLATES = $(BUILD_DIR)/skydns-rc.yaml.in $(BUILD_DIR)/skydns-svc.yaml.in
 KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
 
-.PHONY: clean build build_dir clone test push deps etcd version info
-.INTERMEDIATE: build-kubernetes copy-kubernetes-binaries download-etcd
+.PHONY: clean build build_dir check_dirty clone test push deps version
+.INTERMEDIATE: build_kubernetes copy_kubernetes_binaries download_etcd
 
 all: build
 
@@ -73,20 +73,20 @@ test: clone
 	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-go.sh
 	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-integration.sh
 
-build-kubernetes: $(BUILD_DIR)/rebuild
+build_kubernetes: $(BUILD_DIR)/rebuild
 	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/build-go.sh
-$(K8S_BINARIES_SOURCE): build-kubernetes
+$(K8S_BINARIES_SOURCE): build_kubernetes
 
-copy-kubernetes-binaries: $(K8S_BINARIES_SOURCE)
+copy_kubernetes_binaries: $(K8S_BINARIES_SOURCE)
 	cp -pv $(K8S_BINARIES_SOURCE) $(BUILD_DIR)
 	touch $(K8S_BINARIES_DEST)
-$(K8S_BINARIES_DEST): copy-kubernetes-binaries
+$(K8S_BINARIES_DEST): copy_kubernetes_binaries
 
-download-etcd:
+download_etcd:
 	cd $(BUILD_DIR) && curl -L -O $(ETCD_SOURCE) && tar xzvf $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
 	cp -pv $(addprefix $(ETCD_BINARIES_SOURCE_DIR)/,$(ETCD_BINARIES)) $(BUILD_DIR)
 	touch $(ETCD_BINARIES_DEST)
-$(ETCD_BINARIES_DEST): download-etcd
+$(ETCD_BINARIES_DEST): download_etcd
 
 $(KUBE_DNS_TEMPLATES):
 	curl -f $(GIT_REF_BASE_URL)/cluster/addons/dns/$(shell basename $@) > $@
@@ -105,7 +105,3 @@ build: version clone check_dirty deps
 
 push:
 	echo pushing $(DOCKER_IMAGE); docker push $(DOCKER_IMAGE)
-
-info:
-	@docker version
-	@echo ".version : $$(cat $(BUILD_DIR)/.version 2>/dev/null)"

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -1,23 +1,3 @@
-mkfile_path     := $(abspath $(lastword $(MAKEFILE_LIST)))
-current_dir     := $(patsubst %/,%,$(dir $(mkfile_path)))
-
-BUILD_DIR = _build
-
-K8S_LINUX_BIN_DIR = $(BUILD_DIR)/kubernetes/_output/dockerized/bin/linux/amd64
-K8S_BINARIES = km kubectl
-K8S_BINARIES_SOURCE = $(addprefix $(K8S_LINUX_BIN_DIR)/,$(K8S_BINARIES))
-K8S_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(K8S_BINARIES))
-
-ETCD_IMAGE = etcd
-ETCD_TAG = 2.0.12
-ETCD_BINARIES = etcd etcdctl
-ETCD_BINARIES_SOURCE = $(addprefix $(BUILD_DIR)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64/,$(ETCD_BINARIES))
-ETCD_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(ETCD_BINARIES))
-ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
-
-KUBE_DNS_TEMPLATES = $(BUILD_DIR)/skydns-rc.yaml.in $(BUILD_DIR)/skydns-svc.yaml.in
-KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
-
 GIT_REF ?= v1.0.1-v0.6.1
 GIT_REPO ?= mesosphere/kubernetes
 GIT_REF_BASE_URL = https://raw.githubusercontent.com/mesosphere/kubernetes/$(GIT_REF)
@@ -28,9 +8,25 @@ DOCKER_ORG ?= mesosphere
 DOCKER_REPO ?= $(DOCKER_ORG)/kubernetes
 DOCKER_IMAGE ?= $(DOCKER_REPO):$(VERSION)
 
-BUILDER_IMAGE ?= mesosphere/kubernetes-mesos-build
+BUILD_DIR = _build
 
-.PHONY: clean build test clone_k8s push deps etcd version info
+K8S_BINARIES = km kubectl
+K8S_BINARIES_SOURCE_DIR = $(BUILD_DIR)/kubernetes/_output/dockerized/bin/linux/amd64
+K8S_BINARIES_SOURCE = $(addprefix $(K8S_BINARIES_SOURCE_DIR)/,$(K8S_BINARIES))
+K8S_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(K8S_BINARIES))
+
+ETCD_IMAGE = etcd
+ETCD_TAG = 2.0.12
+ETCD_BINARIES = etcd etcdctl
+ETCD_BINARIES_SOURCE_DIR = $(BUILD_DIR)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64
+ETCD_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(ETCD_BINARIES))
+ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
+
+KUBE_DNS_TEMPLATES = $(BUILD_DIR)/skydns-rc.yaml.in $(BUILD_DIR)/skydns-svc.yaml.in
+KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
+
+.PHONY: clean build clone test push deps etcd version info
+.INTERMEDIATE: build-kubernetes copy-kubernetes-binaries download-etcd
 
 all: build
 
@@ -41,29 +37,42 @@ version:
 	@echo "$(VERSION)" | tee $(BUILD_DIR)/.version
 
 clone:
-	cd $(BUILD_DIR) && \
+	@cd $(BUILD_DIR) && \
 	if [ ! -d "kubernetes" ]; then \
-		git clone --branch $(GIT_REF) https://github.com/$(GIT_REPO).git kubernetes; \
+		git clone --branch $(GIT_REF) https://github.com/$(GIT_REPO).git kubernetes && \
+		touch rebuild; \
 	else \
-		cd kubernetes && git checkout $(GIT_REF); \
+		cd kubernetes && \
+		PREV=$$(git rev-parse HEAD) && \
+		git fetch && git checkout $(GIT_REF) && \
+		if [ "$$PREV" != "$$(git rev-parse HEAD)" ]; then touch ../rebuild; fi; \
+	fi
+
+check_dirty:
+	@cd $(BUILD_DIR)/kubernetes && \
+	if [ -n "$$(git status --porcelain)" ]; then \
+		echo "unclean $(BUILD_DIR)/kubernetes checkout" && \
+		exit 1; \
 	fi
 
 test: clone
 	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-go.sh
 	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-integration.sh
 
-$(K8S_BINARIES_SOURCE):
+build-kubernetes: $(BUILD_DIR)/rebuild
 	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/build-go.sh
-	touch $(BUILD_DIR)/built
+$(K8S_BINARIES_SOURCE): build-kubernetes
 
-$(K8S_BINARIES_DEST): $(K8S_BINARIES_SOURCE)
-	cp -av $(K8S_BINARIES_SOURCE) $(BUILD_DIR)
+copy-kubernetes-binaries: $(K8S_BINARIES_SOURCE)
+	cp -pv $(K8S_BINARIES_SOURCE) $(BUILD_DIR)
+	touch $(K8S_BINARIES_DEST)
+$(K8S_BINARIES_DEST): copy-kubernetes-binaries
 
-$(ETCD_BINARIES_SOURCE):
+download-etcd:
 	cd $(BUILD_DIR) && curl -L -O $(ETCD_SOURCE) && tar xzvf $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
-
-$(ETCD_BINARIES_DEST): $(ETCD_BINARIES_SOURCE)
-	cp -av $(ETCD_BINARIES_SOURCE) $(BUILD_DIR)
+	cp -pv $(addprefix $(ETCD_BINARIES_SOURCE_DIR)/,$(ETCD_BINARIES)) $(BUILD_DIR)
+	touch $(ETCD_BINARIES_DEST)
+$(ETCD_BINARIES_DEST): download-etcd
 
 $(KUBE_DNS_TEMPLATES):
 	curl -f $(GIT_REF_BASE_URL)/cluster/addons/dns/$(shell basename $@) > $@
@@ -76,7 +85,7 @@ $(BUILD_DIR):
 
 deps: $(BUILD_DIR) $(ETCD_BINARIES_DEST) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
 
-build: deps version
+build: clone check_dirty deps version
 	docker build -q -t $(DOCKER_IMAGE) .
 	docker tag -f $(DOCKER_IMAGE) $(DOCKER_REPO):latest
 

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -1,8 +1,13 @@
+# input variables
 GIT_REF ?= v1.0.1-v0.6.1
 GIT_REPO ?= mesosphere/kubernetes
-GIT_REF_BASE_URL = https://raw.githubusercontent.com/mesosphere/kubernetes/$(GIT_REF)
 
-VERSION = v1.0.1-$(shell git describe --tags --dirty)-alpha$(shell if [ -d $(BUILD_DIR) ]; then echo "-unclean"; fi)
+# fixed values
+GIT_REF_BASE_URL = https://raw.githubusercontent.com/mesosphere/kubernetes/$(GIT_REF)
+GIT_REF_MINOR = $(lastword $(subst -, ,$(GIT_REF)))
+GIT_REF_MAJOR = $(firstword $(subst -, ,$(GIT_REF)))
+
+VERSION = $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --always --dirty)$(shell if [ -d $(BUILD_DIR) ]; then echo "-unclean"; fi)-alpha
 
 DOCKER_ORG ?= mesosphere
 DOCKER_REPO ?= $(DOCKER_ORG)/kubernetes

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -4,6 +4,7 @@ GIT_URL ?= https://github.com/mesosphere/kubernetes.git
 DOCKER_ORG ?= mesosphere
 KUBE_ROOT ?=
 SUDO ?=
+POSTFIX ?= -alpha
 
 # fixed values
 SHELL := /bin/bash
@@ -17,13 +18,13 @@ ifneq ($(wildcard $(BUILD_DIR)),)
 	UNCLEAN_INFIX := -unclean
 endif
 ifeq ($(KUBE_ROOT),)
-	VERSION := $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --always --tags --dirty)$(UNCLEAN_INFIX)-alpha
+	VERSION := $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --always --tags --dirty)$(UNCLEAN_INFIX)
 else
 	VERSION := $(GIT_REF)-dev
 endif
 
 DOCKER_REPO = $(DOCKER_ORG)/kubernetes
-DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)
+DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)$(POSTFIX)
 DOCKER_IMAGE_FILE = $(BUILD_DIR)/built-docker-image
 
 # kubernetes binaries distributed in the Docker container
@@ -181,22 +182,38 @@ test: checkout
 
 # install github-release, a tool to upload github release assets
 $(GITHUB_RELEASE):
-	@mkdir -p $(BUILD_DIR)/go && \
+	@mkdir -p $(BUILD_DIR)/go
 	export GOPATH=$$(pwd)/$(BUILD_DIR)/go && \
 	go get github.com/aktau/github-release
 
 # check that the environment variable GITHUB_TOKEN is set, needed to uploaded release assets
 check_github_token:
-	test -n "$$GITHUB_TOKEN"
+	@if [ -z "$$GITHUB_TOKEN" ]; then \
+		echo "To create releases please set GITHUB_TOKEN" && \
+		exit 1; \
+	fi
 
-# upload the kubectl tar.gz for linux/amd64 and darwin/amd64 to github release given by GIT_REF
-release: $(GITHUB_RELEASE) check_github_token checkout $(KUBECTL_BINARIES)
-	$(GITHUB_RELEASE) release -u mesosphere --repo kubernetes --tag $(GIT_REF) --name "Kubernetes on Mesos $(GIT_REF)" --draft
+# upload the kubectl tar.gz for linux/amd64 and darwin/amd64 to github release given by VERSION
+release: $(GITHUB_RELEASE) check_github_token $(KUBECTL_BINARIES)
+	@echo "Releasing kubectl tar.gz's as github assets for tag $(VERSION) on $(GIT_URL)"
+	@if tty -s; then \
+			echo && \
+			echo -n "Continue? [Y/n] " && read YES && if [ -n "$$YES" -a "$$YES" != Y -a "$$YES" != y ]; then exit 1; fi; \
+	fi
+	if $(GITHUB_RELEASE) info -u mesosphere --repo kubernetes --tag $(VERSION); then \
+		echo "Found $(VERSION) release. Will edit." && RELEASE_COMMAND=edit; \
+	else \
+		echo "Creating $(VERSION) draft release"; \
+	fi && \
+	$(GITHUB_RELEASE) $${RELEASE_COMMAND:-release} -u mesosphere --repo kubernetes --tag $(VERSION) --name "Kubernetes on Mesos $(VERSION)" --draft
 	@set -x; for OS in linux darwin; do \
 		BUILD_DIR=$$PWD/$(BUILD_DIR) && \
 		cd $(call K8S_BINARIES_SOURCE_DIR,$$OS) && \
-		TAR=kubectl-$(GIT_REF)-$$OS-amd64.tgz && \
-		tar -cvzf $$BUILD_DIR/$$TAR kubectl && \
+		TAR=kubectl-$(VERSION)-$$OS-amd64.tgz && \
+		tar -czf $$BUILD_DIR/$$TAR kubectl && \
 		cd - &>/dev/null && \
-		$(GITHUB_RELEASE) upload -u mesosphere --repo kubernetes --tag $(GIT_REF) --file $(BUILD_DIR)/$$TAR --name $$TAR || exit 1; \
+		echo "Uploading $$TAR as github asset for tag $(VERSION)" && \
+		$(GITHUB_RELEASE) upload -u mesosphere --repo kubernetes --tag $(VERSION) --file $(BUILD_DIR)/$$TAR --name $$TAR || exit 1; \
 	done
+	@echo
+	@echo "Goto https://github.com/mesosphere/kubernetes/releases/tag/$(VERSION) to edit the release details"

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -30,7 +30,7 @@ ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ET
 KUBE_DNS_TEMPLATES = $(BUILD_DIR)/skydns-rc.yaml.in $(BUILD_DIR)/skydns-svc.yaml.in
 KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
 
-.PHONY: clean build clone test push deps etcd version info
+.PHONY: clean build build_dir clone test push deps etcd version info
 .INTERMEDIATE: build-kubernetes copy-kubernetes-binaries download-etcd
 
 all: build

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -60,7 +60,7 @@ KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
 GITHUB_RELEASE = $(shell pwd)/$(BUILD_DIR)/go/bin/github-release
 
 # meta targets
-.PHONY: clean build build_dir check_dirty checkout clone test push deps version delete_docker_image_file check_github_token release
+.PHONY: clean build build_dir check_dirty checkout clone test push deps version delete_docker_image_file check_github_token github-release-assets
 .INTERMEDIATE: build_kubernetes copy_kubernetes_binaries download_etcd
 
 all: build
@@ -194,7 +194,7 @@ check_github_token:
 	fi
 
 # upload the kubectl tar.gz for linux/amd64 and darwin/amd64 to github release given by VERSION
-release: $(GITHUB_RELEASE) check_github_token $(KUBECTL_BINARIES)
+github-release-assets: $(GITHUB_RELEASE) check_github_token $(KUBECTL_BINARIES)
 	@echo "Releasing kubectl tar.gz's as github assets for tag $(VERSION) on $(GIT_URL)"
 	@if tty -s; then \
 			echo && \

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -38,11 +38,14 @@ all: build
 clean:
 	rm -rf $(BUILD_DIR)
 
-version:
-	@echo "$(VERSION)" | tee $(BUILD_DIR)/.version
-
 build_dir:
-	mkdir -p $(BUILD_DIR)
+	@mkdir -p $(BUILD_DIR)
+
+version: build_dir
+	@echo "GIT_REF=$(GIT_REF)"
+	@echo "VERSION=$(VERSION)"
+	@echo
+	@echo "$(VERSION)" > $(BUILD_DIR)/.version
 
 clone: build_dir
 	@cd $(BUILD_DIR) && \
@@ -93,7 +96,7 @@ $(BUILD_DIR):
 
 deps: $(BUILD_DIR) $(ETCD_BINARIES_DEST) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
 
-build: build_dir clone check_dirty deps version
+build: version clone check_dirty deps
 	docker build -q -t $(DOCKER_IMAGE) .
 	docker tag -f $(DOCKER_IMAGE) $(DOCKER_REPO):latest
 

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -1,65 +1,88 @@
 mkfile_path     := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir     := $(patsubst %/,%,$(dir $(mkfile_path)))
 
-FROM ?= $(current_dir)/_build/k8sm
-TARGET_OBJ = km kubectl
-SOURCE_OBJ = $(TARGET_OBJ:%=$(FROM)/%)
+BUILD_DIR = _build
+
+K8S_LINUX_BIN_DIR = $(BUILD_DIR)/kubernetes/_output/dockerized/bin/linux/amd64
+K8S_BINARIES = km kubectl
+K8S_BINARIES_SOURCE = $(addprefix $(K8S_LINUX_BIN_DIR)/,$(K8S_BINARIES))
+K8S_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(K8S_BINARIES))
 
 ETCD_IMAGE = etcd
 ETCD_TAG = 2.0.12
-ETCD_OUTPUT_DIR = $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64
-ETCD_BINS = $(ETCD_OUTPUT_DIR)/etcd $(ETCD_OUTPUT_DIR)/etcdctl
+ETCD_BINARIES = etcd etcdctl
+ETCD_BINARIES_SOURCE = $(addprefix $(BUILD_DIR)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64/,$(ETCD_BINARIES))
+ETCD_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(ETCD_BINARIES))
 ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
 
-KUBE_DNS_TEMPLATES = skydns-rc.yaml.in skydns-svc.yaml.in
-KUBE_UI_TEMPLATES = kube-ui-rc.yaml kube-ui-svc.yaml
+KUBE_DNS_TEMPLATES = $(BUILD_DIR)/skydns-rc.yaml.in $(BUILD_DIR)/skydns-svc.yaml.in
+KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
 
-ORG ?= mesosphere
-REPO ?= $(ORG)/kubernetes
-REF ?= v1.0.1
-VERSION = $(REF)-$(shell git describe --tags --dirty)-alpha
-IMAGE ?= $(REPO):$(VERSION)
+GIT_REF ?= v1.0.1-v0.6.1
+GIT_REPO ?= mesosphere/kubernetes
+GIT_REF_BASE_URL = https://raw.githubusercontent.com/mesosphere/kubernetes/$(GIT_REF)
+
+VERSION = v1.0.1-$(shell git describe --tags --dirty)-alpha$(shell if [ -d $(BUILD_DIR) ]; then echo "-unclean"; fi)
+
+DOCKER_ORG ?= mesosphere
+DOCKER_REPO ?= $(DOCKER_ORG)/kubernetes
+DOCKER_IMAGE ?= $(DOCKER_REPO):$(VERSION)
+
 BUILDER_IMAGE ?= mesosphere/kubernetes-mesos-build
-REF_BASE_URL = https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/$(REF)
 
-.PHONY: clean build push deps etcd $(ETCD_BINS) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES) version info $(SOURCE_OBJ)
+.PHONY: clean build test clone_k8s push deps etcd version info
 
 all: build
 
 clean:
-	rm -rf $(TARGET_OBJ) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
-
-deps: $(ETCD_BINS) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES) $(SOURCE_OBJ)
+	rm -rf $(BUILD_DIR)
 
 version:
-	@echo "$(VERSION)" | tee .version
+	@echo "$(VERSION)" | tee $(BUILD_DIR)/.version
 
-build: deps version
-	cp -pv $(SOURCE_OBJ) .
-	docker build -q -t $(IMAGE) .
-	docker tag -f $(IMAGE) $(REPO):latest
+clone:
+	cd $(BUILD_DIR) && \
+	if [ ! -d "kubernetes" ]; then \
+		git clone --branch $(GIT_REF) https://github.com/$(GIT_REPO).git kubernetes; \
+	else \
+		cd kubernetes && git checkout $(GIT_REF); \
+	fi
 
-push:
-	echo pushing $(IMAGE); docker push $(IMAGE)
+test: clone
+	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-go.sh
+	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-integration.sh
 
-etcd:
-	test 1 = 1 $(ETCD_BINS:%= -a -f "%") || ( \
-		curl -L -O $(ETCD_SOURCE) && tar xzvf $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz)
+$(K8S_BINARIES_SOURCE):
+	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/build-go.sh
+	touch $(BUILD_DIR)/built
 
-$(ETCD_BINS): etcd
-	test -f "$$(basename $@)" || cp -v $@ .
+$(K8S_BINARIES_DEST): $(K8S_BINARIES_SOURCE)
+	cp -av $(K8S_BINARIES_SOURCE) $(BUILD_DIR)
+
+$(ETCD_BINARIES_SOURCE):
+	cd $(BUILD_DIR) && curl -L -O $(ETCD_SOURCE) && tar xzvf $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
+
+$(ETCD_BINARIES_DEST): $(ETCD_BINARIES_SOURCE)
+	cp -av $(ETCD_BINARIES_SOURCE) $(BUILD_DIR)
 
 $(KUBE_DNS_TEMPLATES):
-	curl -f $(REF_BASE_URL)/cluster/addons/dns/$@ > $@
+	curl -f $(GIT_REF_BASE_URL)/cluster/addons/dns/$(shell basename $@) > $@
 
 $(KUBE_UI_TEMPLATES):
-	curl -f $(REF_BASE_URL)/cluster/addons/kube-ui/$@ > $@
+	curl -f $(GIT_REF_BASE_URL)/cluster/addons/kube-ui/$(shell basename $@) > $@
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+deps: $(BUILD_DIR) $(ETCD_BINARIES_DEST) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
+
+build: deps version
+	docker build -q -t $(DOCKER_IMAGE) .
+	docker tag -f $(DOCKER_IMAGE) $(DOCKER_REPO):latest
+
+push:
+	echo pushing $(DOCKER_IMAGE); docker push $(DOCKER_IMAGE)
 
 info:
 	@docker version
-	@echo ".version : $$(cat .version 2>/dev/null)"
-
-$(SOURCE_OBJ):
-	test -x $@ || \
-		docker run --rm -ti -v $(FROM):/target -e GIT_BRANCH=$(REF) $(BUILDER_IMAGE) \
-		bash -c './hack/build-cross.sh && cp -vp _output/local/bin/linux/amd64/* /target/ && find _output/local/bin/ -name kubectl | while IFS=/ read -r a b c os arch app; do cp -vp "$$a/$$b/$$c/$$os/$$arch/$$app" "/target/$${app}-$${os}-$${arch}"; done'
+	@echo ".version : $$(cat $(BUILD_DIR)/.version 2>/dev/null)"

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -41,7 +41,10 @@ clean:
 version:
 	@echo "$(VERSION)" | tee $(BUILD_DIR)/.version
 
-clone:
+build_dir:
+	mkdir -p $(BUILD_DIR)
+
+clone: build_dir
 	@cd $(BUILD_DIR) && \
 	if [ ! -d "kubernetes" ]; then \
 		git clone --branch $(GIT_REF) https://github.com/$(GIT_REPO).git kubernetes && \
@@ -90,7 +93,7 @@ $(BUILD_DIR):
 
 deps: $(BUILD_DIR) $(ETCD_BINARIES_DEST) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
 
-build: clone check_dirty deps version
+build: build_dir clone check_dirty deps version
 	docker build -q -t $(DOCKER_IMAGE) .
 	docker tag -f $(DOCKER_IMAGE) $(DOCKER_REPO):latest
 

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -34,6 +34,10 @@ ETCD_BINARIES_SOURCE_DIR = $(BUILD_DIR)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64
 ETCD_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(ETCD_BINARIES))
 ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ETCD_TAR)
 
+# s6 overlay used as init process in the Docker container
+S6_TAR = s6-overlay-amd64.tar.gz
+S6_URL = https://github.com/just-containers/s6-overlay/releases/download/v1.13.0.0/$(S6_TAR)
+
 # kubernetes addons: kube-dns and kube-ui
 KUBE_DNS_TEMPLATES = $(BUILD_DIR)/skydns-rc.yaml.in $(BUILD_DIR)/skydns-svc.yaml.in
 KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
@@ -100,10 +104,13 @@ $(K8S_BINARIES_DEST): copy_kubernetes_binaries
 
 # download etcd and extract it to _output/etcd-...
 $(BUILD_DIR)/$(ETCD_TAR):
-	cd $(BUILD_DIR) && curl -L -O $(ETCD_SOURCE) && tar xzvf $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
+	cd $(BUILD_DIR) && curl -L -O $(ETCD_SOURCE) && tar xzvf $(ETCD_TAR)
 	cp -pv $(addprefix $(ETCD_BINARIES_SOURCE_DIR)/,$(ETCD_BINARIES)) $(BUILD_DIR)
 	touch $(ETCD_BINARIES_DEST)
 $(ETCD_BINARIES_DEST): $(BUILD_DIR)/$(ETCD_TAR)
+
+$(BUILD_DIR)/$(S6_TAR):
+	cd "$(BUILD_DIR)" && curl -L -O $(S6_URL)
 
 # copy the kube-dns specs from the kubernetes repo to _build
 $(KUBE_DNS_TEMPLATES): clone
@@ -114,7 +121,7 @@ $(KUBE_UI_TEMPLATES): clone
 	cp $(BUILD_DIR)/kubernetes/cluster/addons/kube-ui/$(shell basename $@) $@
 
 # package build targets
-deps: build_dir $(ETCD_BINARIES_DEST) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
+deps: build_dir $(ETCD_BINARIES_DEST) $(BUILD_DIR)/$(S6_TAR) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
 build: version clone check_dirty deps
 	docker build -t $(DOCKER_IMAGE) .
 	docker tag -f $(DOCKER_IMAGE) $(DOCKER_REPO):latest

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -201,11 +201,11 @@ release: $(GITHUB_RELEASE) check_github_token $(KUBECTL_BINARIES)
 			echo -n "Continue? [Y/n] " && read YES && if [ -n "$$YES" -a "$$YES" != Y -a "$$YES" != y ]; then exit 1; fi; \
 	fi
 	@if $(GITHUB_RELEASE) info -u mesosphere --repo kubernetes | grep -q $(VERSION); then \
-		echo "Found $(VERSION) release. Will edit." && RELEASE_COMMAND=edit; \
+		echo "Found $(VERSION) release"; \
 	else \
+		$(GITHUB_RELEASE) release -u mesosphere --repo kubernetes --tag $(VERSION) --name "Kubernetes on Mesos $(VERSION)" --draft && \
 		echo "Creating $(VERSION) draft release"; \
-	fi && \
-	$(GITHUB_RELEASE) $${RELEASE_COMMAND:-release} -u mesosphere --repo kubernetes --tag $(VERSION) --name "Kubernetes on Mesos $(VERSION)" --draft
+	fi
 	@for OS in linux darwin; do \
 		BUILD_DIR=$$PWD/$(BUILD_DIR) && \
 		cd $(call K8S_BINARIES_SOURCE_DIR,$$OS) && \

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -2,6 +2,7 @@
 GIT_REF ?= v1.0.2-v0.6.1
 GIT_URL ?= https://github.com/mesosphere/kubernetes.git
 DOCKER_ORG ?= mesosphere
+KUBE_ROOT ?=
 
 # fixed values
 GIT_REF_MINOR = $(lastword $(subst -, ,$(GIT_REF)))
@@ -10,16 +11,25 @@ GIT_REF_MAJOR = $(firstword $(subst -, ,$(GIT_REF)))
 BUILD_DIR = _build
 
 ifneq ($(wildcard $(BUILD_DIR)),)
-UNCLEAN_INFIX := -unclean
+	UNCLEAN_INFIX := -unclean
 endif
-VERSION := $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --always --tags --dirty)$(UNCLEAN_INFIX)-alpha
+ifeq ($(KUBE_ROOT),)
+	VERSION := $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --always --tags --dirty)$(UNCLEAN_INFIX)-alpha
+else
+	VERSION := $(GIT_REF)-dev
+endif
 
 DOCKER_REPO = $(DOCKER_ORG)/kubernetes
 DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)
 
 # kubernetes binaries distributed in the Docker container
 K8S_BINARIES = km kubectl
-K8S_BINARIES_SOURCE_DIR = $(BUILD_DIR)/kubernetes/_output/dockerized/bin/$(1)/amd64
+ifeq ($(KUBE_ROOT),)
+	K8S_ROOT = $(BUILD_DIR)/kubernetes
+else
+	K8S_ROOT = $(KUBE_ROOT)
+endif
+K8S_BINARIES_SOURCE_DIR = $(K8S_ROOT)/_output/dockerized/bin/$(1)/amd64
 K8S_BINARIES_SOURCE = $(addprefix $(call K8S_BINARIES_SOURCE_DIR,linux)/,$(K8S_BINARIES))
 K8S_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(K8S_BINARIES))
 KUBECTL_BINARIES = $(call K8S_BINARIES_SOURCE_DIR,linux)/kubectl $(call K8S_BINARIES_SOURCE_DIR,darwin)/kubectl
@@ -45,7 +55,7 @@ KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
 GITHUB_RELEASE = $(shell pwd)/$(BUILD_DIR)/go/bin/github-release
 
 # meta targets
-.PHONY: clean build build_dir check_dirty clone test push deps version check_github_token release
+.PHONY: clean build build_dir check_dirty checkout clone test push deps version check_github_token release
 .INTERMEDIATE: build_kubernetes copy_kubernetes_binaries download_etcd
 
 all: build
@@ -76,6 +86,9 @@ clone: build_dir
 		if [ "$$PREV" != "$$(git rev-parse HEAD)" ]; then touch ../rebuild; fi; \
 	fi
 
+ifeq ($(KUBE_ROOT),)
+checkout: clone
+
 # check that everything in the repo is commited
 check_dirty:
 	@cd $(BUILD_DIR)/kubernetes && \
@@ -84,14 +97,21 @@ check_dirty:
 		exit 1; \
 	fi
 
-# run the kubernetes unit and integration tests inside Docker
-test: clone
-	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-go.sh
-	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-integration.sh
-
 # cross-compile the kubernetes binaries inside Docker
 build_kubernetes: $(BUILD_DIR)/rebuild
-	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/build-cross.sh
+	cd "${K8S_ROOT}" && KUBERNETES_CONTRIB=mesos build/run.sh hack/build-cross.sh
+else
+checkout:
+	@test -d $(KUBE_ROOT)
+check_dirty:
+build_kubernetes:
+	@echo "Build linux/amd64 binaries in ${K8S_ROOT}:"
+	@echo
+	@echo "    KUBERNETES_CONTRIB=mesos build/run.sh hack/build-go.sh"
+	@echo
+	@exit 1
+endif
+
 $(K8S_BINARIES_SOURCE): build_kubernetes
 $(KUBECTL_BINARIES): build_kubernetes
 
@@ -112,22 +132,27 @@ $(BUILD_DIR)/$(S6_TAR):
 	cd "$(BUILD_DIR)" && curl -L -O $(S6_URL)
 
 # copy the kube-dns specs from the kubernetes repo to _build
-$(KUBE_DNS_TEMPLATES): clone
-	cp $(BUILD_DIR)/kubernetes/cluster/addons/dns/$(shell basename $@) $@
+$(KUBE_DNS_TEMPLATES): checkout
+	cp ${K8S_ROOT}/cluster/addons/dns/$(shell basename $@) $@
 
 # copy the kube-ui specs from the kubernetes repo to build_
-$(KUBE_UI_TEMPLATES): clone
-	cp $(BUILD_DIR)/kubernetes/cluster/addons/kube-ui/$(shell basename $@) $@
+$(KUBE_UI_TEMPLATES): checkout
+	cp ${K8S_ROOT}/cluster/addons/kube-ui/$(shell basename $@) $@
 
 # package build targets
 deps: build_dir $(ETCD_BINARIES_DEST) $(BUILD_DIR)/$(S6_TAR) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
-build: version clone check_dirty deps
+build: version checkout check_dirty deps
 	docker build -t $(DOCKER_IMAGE) .
 	docker tag -f $(DOCKER_IMAGE) $(DOCKER_REPO):latest
 
 # push the Docker image to the Docker hub
 push:
 	echo pushing $(DOCKER_IMAGE); docker push $(DOCKER_IMAGE)
+
+# run the kubernetes unit and integration tests inside Docker
+test: checkout
+	cd "${K8S_ROOT}" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-go.sh
+	cd "${K8S_ROOT}" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-integration.sh
 
 # install github-release, a tool to upload github release assets
 $(GITHUB_RELEASE):
@@ -140,7 +165,7 @@ check_github_token:
 	test -n "$$GITHUB_TOKEN"
 
 # upload the kubectl tar.gz for linux/amd64 and darwin/amd64 to github release given by GIT_REF
-release: $(GITHUB_RELEASE) check_github_token clone $(KUBECTL_BINARIES)
+release: $(GITHUB_RELEASE) check_github_token checkout $(KUBECTL_BINARIES)
 	$(GITHUB_RELEASE) release -u mesosphere --repo kubernetes --tag $(GIT_REF) --name "Kubernetes on Mesos $(GIT_REF)" --draft
 	@set -x; for OS in linux darwin; do \
 		BUILD_DIR=$$PWD/$(BUILD_DIR) && \

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -96,6 +96,7 @@ clone: build_dir
 		if [ "$$PREV" != "$$(git rev-parse HEAD)" ]; then touch ../rebuild; fi; \
 	fi
 
+# behave differently for a set or unset KUBE_ROOT
 ifeq ($(KUBE_ROOT),)
 checkout: clone
 
@@ -138,6 +139,7 @@ $(BUILD_DIR)/$(ETCD_TAR):
 	touch $(ETCD_BINARIES_DEST)
 $(ETCD_BINARIES_DEST): $(BUILD_DIR)/$(ETCD_TAR)
 
+# download S6
 $(BUILD_DIR)/$(S6_TAR):
 	cd "$(BUILD_DIR)" && curl -L -O $(S6_URL)
 

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -1,5 +1,5 @@
 # input variables
-GIT_REF ?= v1.0.1-v0.6.1
+GIT_REF ?= v1.0.2-v0.6.1
 GIT_REPO ?= mesosphere/kubernetes
 DOCKER_ORG ?= mesosphere
 

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -216,4 +216,8 @@ github-release-assets: $(GITHUB_RELEASE) check_github_token $(KUBECTL_BINARIES)
 		$(GITHUB_RELEASE) upload -u mesosphere --repo kubernetes --tag $(VERSION) --file $(BUILD_DIR)/$$TAR --name $$TAR || exit 1; \
 	done
 	@echo
-	@echo "Goto https://github.com/mesosphere/kubernetes/releases/tag/$(VERSION) to edit the release details"
+	@URL="https://github.com/mesosphere/kubernetes/releases/tag/$(VERSION)" && \
+	if ! curl -f -q "$$URL" &>/dev/null; then \
+		URL="https://github.com/mesosphere/kubernetes/releases"; \
+	fi && \
+	echo "Goto $$URL to edit the release details"

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -28,10 +28,11 @@ KUBECTL_BINARIES = $(call K8S_BINARIES_SOURCE_DIR,linux)/kubectl $(call K8S_BINA
 # etcd distributed in the Docker container
 ETCD_IMAGE = etcd
 ETCD_TAG = 2.0.12
+ETCD_TAR = $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
 ETCD_BINARIES = etcd etcdctl
 ETCD_BINARIES_SOURCE_DIR = $(BUILD_DIR)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64
 ETCD_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(ETCD_BINARIES))
-ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
+ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ETCD_TAR)
 
 # kubernetes addons: kube-dns and kube-ui
 KUBE_DNS_TEMPLATES = $(BUILD_DIR)/skydns-rc.yaml.in $(BUILD_DIR)/skydns-svc.yaml.in
@@ -98,11 +99,11 @@ copy_kubernetes_binaries: $(K8S_BINARIES_SOURCE)
 $(K8S_BINARIES_DEST): copy_kubernetes_binaries
 
 # download etcd and extract it to _output/etcd-...
-download_etcd:
+$(BUILD_DIR)/$(ETCD_TAR):
 	cd $(BUILD_DIR) && curl -L -O $(ETCD_SOURCE) && tar xzvf $(ETCD_IMAGE)-v$(ETCD_TAG)-linux-amd64.tar.gz
 	cp -pv $(addprefix $(ETCD_BINARIES_SOURCE_DIR)/,$(ETCD_BINARIES)) $(BUILD_DIR)
 	touch $(ETCD_BINARIES_DEST)
-$(ETCD_BINARIES_DEST): download_etcd
+$(ETCD_BINARIES_DEST): $(BUILD_DIR)/$(ETCD_TAR)
 
 # copy the kube-dns specs from the kubernetes repo to _build
 $(KUBE_DNS_TEMPLATES): clone

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -19,9 +19,10 @@ DOCKER_REPO = $(DOCKER_ORG)/kubernetes
 DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)
 
 K8S_BINARIES = km kubectl
-K8S_BINARIES_SOURCE_DIR = $(BUILD_DIR)/kubernetes/_output/dockerized/bin/linux/amd64
-K8S_BINARIES_SOURCE = $(addprefix $(K8S_BINARIES_SOURCE_DIR)/,$(K8S_BINARIES))
+K8S_BINARIES_SOURCE_DIR = $(BUILD_DIR)/kubernetes/_output/dockerized/bin/$(1)/amd64
+K8S_BINARIES_SOURCE = $(addprefix $(call K8S_BINARIES_SOURCE_DIR,linux)/,$(K8S_BINARIES))
 K8S_BINARIES_DEST = $(addprefix $(BUILD_DIR)/,$(K8S_BINARIES))
+KUBECTL_BINARIES = $(call K8S_BINARIES_SOURCE_DIR,linux)/kubectl $(call K8S_BINARIES_SOURCE_DIR,darwin)/kubectl
 
 ETCD_IMAGE = etcd
 ETCD_TAG = 2.0.12
@@ -33,7 +34,9 @@ ETCD_SOURCE = https://github.com/coreos/etcd/releases/download/v$(ETCD_TAG)/$(ET
 KUBE_DNS_TEMPLATES = $(BUILD_DIR)/skydns-rc.yaml.in $(BUILD_DIR)/skydns-svc.yaml.in
 KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
 
-.PHONY: clean build build_dir check_dirty clone test push deps version
+GITHUB_RELEASE = $(shell pwd)/$(BUILD_DIR)/go/bin/github-release
+
+.PHONY: clean build build_dir check_dirty clone test push deps version check_github_token release
 .INTERMEDIATE: build_kubernetes copy_kubernetes_binaries download_etcd
 
 all: build
@@ -74,7 +77,7 @@ test: clone
 	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/test-integration.sh
 
 build_kubernetes: $(BUILD_DIR)/rebuild
-	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/build-go.sh
+	cd "$(BUILD_DIR)/kubernetes" && KUBERNETES_CONTRIB=mesos build/run.sh hack/build-cross.sh
 $(K8S_BINARIES_SOURCE): build_kubernetes
 
 copy_kubernetes_binaries: $(K8S_BINARIES_SOURCE)
@@ -105,3 +108,24 @@ build: version clone check_dirty deps
 
 push:
 	echo pushing $(DOCKER_IMAGE); docker push $(DOCKER_IMAGE)
+
+$(GITHUB_RELEASE):
+	@mkdir -p $(BUILD_DIR)/go && \
+	export GOPATH=$$(pwd)/$(BUILD_DIR)/go && \
+	go get github.com/aktau/github-release
+
+check_github_token:
+	test -n "$$GITHUB_TOKEN"
+
+$(KUBECTL_BINARIES): build_kubernetes
+
+release: $(GITHUB_RELEASE) check_github_token clone $(KUBECTL_BINARIES)
+	$(GITHUB_RELEASE) release -u mesosphere --repo kubernetes --tag $(GIT_REF) --name "Kubernetes on Mesos $(GIT_REF)" --draft
+	@set -x; for OS in linux darwin; do \
+		BUILD_DIR=$$PWD/$(BUILD_DIR) && \
+		cd $(call K8S_BINARIES_SOURCE_DIR,$$OS) && \
+		TAR=kubectl-$(GIT_REF)-$$OS-amd64.tgz && \
+		tar -cvzf $$BUILD_DIR/$$TAR kubectl && \
+		cd - &>/dev/null && \
+		$(GITHUB_RELEASE) upload -u mesosphere --repo kubernetes --tag $(GIT_REF) --file $(BUILD_DIR)/$$TAR --name $$TAR || exit 1; \
+	done

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -1,10 +1,9 @@
 # input variables
 GIT_REF ?= v1.0.2-v0.6.1
-GIT_REPO ?= mesosphere/kubernetes
+GIT_URL ?= https://github.com/mesosphere/kubernetes
 DOCKER_ORG ?= mesosphere
 
 # fixed values
-GIT_REF_BASE_URL = https://raw.githubusercontent.com/mesosphere/kubernetes/$(GIT_REF)
 GIT_REF_MINOR = $(lastword $(subst -, ,$(GIT_REF)))
 GIT_REF_MAJOR = $(firstword $(subst -, ,$(GIT_REF)))
 
@@ -68,7 +67,7 @@ version: build_dir
 clone: build_dir
 	@cd $(BUILD_DIR) && \
 	if [ ! -d "kubernetes" ]; then \
-		git clone --branch $(GIT_REF) https://github.com/$(GIT_REPO).git kubernetes && \
+		git clone --branch $(GIT_REF) $(GIT_URL)/$(GIT_REPO).git kubernetes && \
 		touch rebuild; \
 	else \
 		cd kubernetes && \

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -72,8 +72,14 @@ build_dir:
 
 # print out the version and create .version
 version: build_dir
-	@echo "GIT_REF=$(GIT_REF)"
+	@if [ -n "$(KUBE_ROOT)" ]; then \
+		echo "KUBE_ROOT=$(KUBE_ROOT)"; \
+	else \
+		echo "GIT_URL=$(GIT_URL)" && \
+		echo "GIT_REF=$(GIT_REF)"; \
+	fi
 	@echo "VERSION=$(VERSION)"
+	@echo "DOCKER_IMAGE=$(DOCKER_IMAGE)"
 	@echo
 	@echo "$(VERSION)" > $(BUILD_DIR)/.version
 

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -8,7 +8,7 @@ GIT_REF_BASE_URL = https://raw.githubusercontent.com/mesosphere/kubernetes/$(GIT
 GIT_REF_MINOR = $(lastword $(subst -, ,$(GIT_REF)))
 GIT_REF_MAJOR = $(firstword $(subst -, ,$(GIT_REF)))
 
-VERSION = $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --always --dirty)$(shell if [ -d $(BUILD_DIR) ]; then echo "-unclean"; fi)-alpha
+VERSION = $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --always --tags --dirty)$(shell if [ -d $(BUILD_DIR) ]; then echo "-unclean"; fi)-alpha
 
 DOCKER_REPO = $(DOCKER_ORG)/kubernetes
 DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -1,6 +1,7 @@
 # input variables
 GIT_REF ?= v1.0.1-v0.6.1
 GIT_REPO ?= mesosphere/kubernetes
+DOCKER_ORG ?= mesosphere
 
 # fixed values
 GIT_REF_BASE_URL = https://raw.githubusercontent.com/mesosphere/kubernetes/$(GIT_REF)
@@ -9,9 +10,8 @@ GIT_REF_MAJOR = $(firstword $(subst -, ,$(GIT_REF)))
 
 VERSION = $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --always --dirty)$(shell if [ -d $(BUILD_DIR) ]; then echo "-unclean"; fi)-alpha
 
-DOCKER_ORG ?= mesosphere
-DOCKER_REPO ?= $(DOCKER_ORG)/kubernetes
-DOCKER_IMAGE ?= $(DOCKER_REPO):$(VERSION)
+DOCKER_REPO = $(DOCKER_ORG)/kubernetes
+DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)
 
 BUILD_DIR = _build
 

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -104,15 +104,16 @@ download_etcd:
 	touch $(ETCD_BINARIES_DEST)
 $(ETCD_BINARIES_DEST): download_etcd
 
-$(KUBE_DNS_TEMPLATES):
-	curl -f $(GIT_REF_BASE_URL)/cluster/addons/dns/$(shell basename $@) > $@
+# copy the kube-dns specs from the kubernetes repo to _build
+$(KUBE_DNS_TEMPLATES): clone
+	cp $(BUILD_DIR)/kubernetes/cluster/addons/dns/$(shell basename $@) $@
 
-$(KUBE_UI_TEMPLATES):
-	curl -f $(GIT_REF_BASE_URL)/cluster/addons/kube-ui/$(shell basename $@) > $@
-
-deps: build_dir $(ETCD_BINARIES_DEST) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
+# copy the kube-ui specs from the kubernetes repo to build_
+$(KUBE_UI_TEMPLATES): clone
+	cp $(BUILD_DIR)/kubernetes/cluster/addons/kube-ui/$(shell basename $@) $@
 
 # package build targets
+deps: build_dir $(ETCD_BINARIES_DEST) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
 build: version clone check_dirty deps
 	docker build -q -t $(DOCKER_IMAGE) .
 	docker tag -f $(DOCKER_IMAGE) $(DOCKER_REPO):latest

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -8,12 +8,15 @@ GIT_REF_BASE_URL = https://raw.githubusercontent.com/mesosphere/kubernetes/$(GIT
 GIT_REF_MINOR = $(lastword $(subst -, ,$(GIT_REF)))
 GIT_REF_MAJOR = $(firstword $(subst -, ,$(GIT_REF)))
 
-VERSION = $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --always --tags --dirty)$(shell if [ -d $(BUILD_DIR) ]; then echo "-unclean"; fi)-alpha
+BUILD_DIR = _build
+
+ifneq ($(wildcard $(BUILD_DIR)),)
+UNCLEAN_INFIX := -unclean
+endif
+VERSION := $(GIT_REF_MAJOR)-$(shell git describe --match $(GIT_REF_MINOR) --always --tags --dirty)$(UNCLEAN_INFIX)-alpha
 
 DOCKER_REPO = $(DOCKER_ORG)/kubernetes
 DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)
-
-BUILD_DIR = _build
 
 K8S_BINARIES = km kubectl
 K8S_BINARIES_SOURCE_DIR = $(BUILD_DIR)/kubernetes/_output/dockerized/bin/linux/amd64

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -3,6 +3,7 @@ GIT_REF ?= v1.0.2-v0.6.1
 GIT_URL ?= https://github.com/mesosphere/kubernetes.git
 DOCKER_ORG ?= mesosphere
 KUBE_ROOT ?=
+SUDO ?=
 
 # fixed values
 SHELL := /bin/bash
@@ -64,7 +65,7 @@ GITHUB_RELEASE = $(shell pwd)/$(BUILD_DIR)/go/bin/github-release
 all: build
 
 clean:
-	rm -rf $(BUILD_DIR)
+	$(SUDO) rm -rf $(BUILD_DIR)
 
 build_dir:
 	@mkdir -p $(BUILD_DIR)

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -5,6 +5,8 @@ DOCKER_ORG ?= mesosphere
 KUBE_ROOT ?=
 
 # fixed values
+SHELL := /bin/bash
+
 GIT_REF_MINOR = $(lastword $(subst -, ,$(GIT_REF)))
 GIT_REF_MAJOR = $(firstword $(subst -, ,$(GIT_REF)))
 

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -1,6 +1,6 @@
 # input variables
 GIT_REF ?= v1.0.2-v0.6.1
-GIT_URL ?= https://github.com/mesosphere/kubernetes
+GIT_URL ?= https://github.com/mesosphere/kubernetes.git
 DOCKER_ORG ?= mesosphere
 
 # fixed values
@@ -67,7 +67,7 @@ version: build_dir
 clone: build_dir
 	@cd $(BUILD_DIR) && \
 	if [ ! -d "kubernetes" ]; then \
-		git clone --branch $(GIT_REF) $(GIT_URL)/$(GIT_REPO).git kubernetes && \
+		git clone --branch $(GIT_REF) $(GIT_URL) kubernetes && \
 		touch rebuild; \
 	else \
 		cd kubernetes && \

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -23,6 +23,7 @@ endif
 
 DOCKER_REPO = $(DOCKER_ORG)/kubernetes
 DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)
+DOCKER_IMAGE_FILE = $(BUILD_DIR)/built-docker-image
 
 # kubernetes binaries distributed in the Docker container
 K8S_BINARIES = km kubectl
@@ -57,7 +58,7 @@ KUBE_UI_TEMPLATES = $(BUILD_DIR)/kube-ui-rc.yaml $(BUILD_DIR)/kube-ui-svc.yaml
 GITHUB_RELEASE = $(shell pwd)/$(BUILD_DIR)/go/bin/github-release
 
 # meta targets
-.PHONY: clean build build_dir check_dirty checkout clone test push deps version check_github_token release
+.PHONY: clean build build_dir check_dirty checkout clone test push deps version delete_docker_image_file check_github_token release
 .INTERMEDIATE: build_kubernetes copy_kubernetes_binaries download_etcd
 
 all: build
@@ -134,22 +135,35 @@ $(BUILD_DIR)/$(S6_TAR):
 	cd "$(BUILD_DIR)" && curl -L -O $(S6_URL)
 
 # copy the kube-dns specs from the kubernetes repo to _build
-$(KUBE_DNS_TEMPLATES): checkout
+$(KUBE_DNS_TEMPLATES):
 	cp ${K8S_ROOT}/cluster/addons/dns/$(shell basename $@) $@
 
 # copy the kube-ui specs from the kubernetes repo to build_
-$(KUBE_UI_TEMPLATES): checkout
+$(KUBE_UI_TEMPLATES):
 	cp ${K8S_ROOT}/cluster/addons/kube-ui/$(shell basename $@) $@
 
 # package build targets
+delete_docker_image_file:
+	@rm -f "$(DOCKER_IMAGE_FILE)"
 deps: build_dir $(ETCD_BINARIES_DEST) $(BUILD_DIR)/$(S6_TAR) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
-build: version checkout check_dirty deps
+build: version delete_docker_image_file checkout check_dirty deps
 	docker build -t $(DOCKER_IMAGE) .
 	docker tag -f $(DOCKER_IMAGE) $(DOCKER_REPO):latest
+	@echo $(DOCKER_IMAGE) > $(DOCKER_IMAGE_FILE)
 
 # push the Docker image to the Docker hub
 push:
-	echo pushing $(DOCKER_IMAGE); docker push $(DOCKER_IMAGE)
+	@if [ ! -f $(DOCKER_IMAGE_FILE) ]; then \
+		echo "No docker image ready to push" && \
+		exit 1; \
+	else \
+		echo "Going to push the docker image $$(< $(DOCKER_IMAGE_FILE))" && \
+		if tty -s; then \
+			echo && \
+			echo -n "Continue? [Y/n] " && read YES && if [ -n "$$YES" -a "$$YES" != Y -a "$$YES" != y ]; then exit 1; fi; \
+		fi && \
+		docker push $$(< $(DOCKER_IMAGE_FILE)); \
+	fi
 
 # run the kubernetes unit and integration tests inside Docker
 test: checkout

--- a/hack/images/dcos/Makefile
+++ b/hack/images/dcos/Makefile
@@ -115,7 +115,7 @@ $(KUBE_UI_TEMPLATES): clone
 # package build targets
 deps: build_dir $(ETCD_BINARIES_DEST) $(K8S_BINARIES_DEST) $(KUBE_DNS_TEMPLATES) $(KUBE_UI_TEMPLATES)
 build: version clone check_dirty deps
-	docker build -q -t $(DOCKER_IMAGE) .
+	docker build -t $(DOCKER_IMAGE) .
 	docker tag -f $(DOCKER_IMAGE) $(DOCKER_REPO):latest
 
 # push the Docker image to the Docker hub

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -24,7 +24,7 @@ $ GIT_REF=v1.0.5-v0.6.1 make push
 Moreover, there are the following variables can be customized via the command line:
 
 ```make
-GIT_REPO ?= mesosphere/kubernetes
+GIT_URL ?= https://github.com/mesosphere/kubernetes
 DOCKER_ORG ?= mesosphere
 ```
 

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -57,35 +57,37 @@ Some prerequisites:
 - build yourself a kubectl using the Kubernetes build process (`make`)
 - wait until kubernetes is up
 
-
 ```shell
 $ export KUBERNETES_MASTER=http://{the-dcos-host-your-kubernetes-master-is-running-on}/service/kubernetes/api
+$ kubectl config set-cluster dcos --server=$KUBERNETES_MASTER
+$ kubectl config set-context dcos
+$ kubectl config use-context dcos
 
-$ bin/kubectl get pods --all-namespaces
+$ kubectl get pods --all-namespaces
 NAMESPACE     NAME                READY     STATUS    RESTARTS   AGE
 kube-system   kube-dns-v8-vruvs   4/4       Running   0          22h
 kube-system   kube-ui-v1-1r5km    1/1       Running   0          22h
 
-$ bin/kubectl create -f kubernetes/examples/guestbook/redis-master.json 
+$ kubectl create -f kubernetes/examples/guestbook/redis-master.json 
 pods/redis-master-2
-$ bin/kubectl create -f kubernetes/examples/guestbook/redis-master-service.json 
+$ kubectl create -f kubernetes/examples/guestbook/redis-master-service.json 
 services/redismaster
-$ bin/kubectl create -f kubernetes/examples/guestbook/redis-slave-controller.json 
+$ kubectl create -f kubernetes/examples/guestbook/redis-slave-controller.json 
 replicationControllers/redis-slave-controller
-$ bin/kubectl create -f kubernetes/examples/guestbook/redis-slave-service.json 
+$ kubectl create -f kubernetes/examples/guestbook/redis-slave-service.json 
 services/redisslave
-$ bin/kubectl create -f kubernetes/examples/guestbook/frontend-controller.json 
+$ kubectl create -f kubernetes/examples/guestbook/frontend-controller.json 
 replicationControllers/frontend-controller
-$ bin/kubectl create -f kubernetes/examples/guestbook/frontend-service.json 
+$ kubectl create -f kubernetes/examples/guestbook/frontend-service.json 
 services/frontend
 
-$ bin/kubectl get pods
+$ kubectl get pods
 POD                        IP          CONTAINER(S)  IMAGE(S)        HOST                             LABELS         STATUS   CREATED
 frontend-controller-jf2zt  172.17.0.8  php-redis     jdef/php-redis  ec2-52-24-192-202.../10.0.0.221  name=frontend  Running  51s
 frontend-controller-kypr9  172.17.0.6  php-redis     jdef/php-redis  ec2-52-24-218-42.../10.0.0.223   name=frontend  Running  51s
 ...
 
-$ bin/kubectl exec -p frontend-controller-jf2zt -c php-redis -ti curl http://frontend
+$ kubectl exec -p frontend-controller-jf2zt -c php-redis -ti curl http://frontend
 <html ng-app="redis">
   <head>
     <title>Guestbook</title>

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -30,6 +30,7 @@ GIT_URL ?= https://github.com/mesosphere/kubernetes
 DOCKER_ORG ?= mesosphere
 KUBE_ROOT ?=
 SUDO ?=
+POSTFIX ?= -alpha
 ```
 
 If you are on Linux, build the dockerized kubernetes binaries most probably results in file being owned by root. Set `SUDO=sudo` to get them deleted as normal user:

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -27,6 +27,13 @@ Moreover, there are the following variables can be customized via the command li
 GIT_URL ?= https://github.com/mesosphere/kubernetes
 DOCKER_ORG ?= mesosphere
 KUBE_ROOT ?=
+SUDO ?=
+```
+
+If you are on Linux, build the dockerized kubernetes binaries most probably results in file being owned by root. Set `SUDO=sudo` to get them deleted as normal user:
+
+```bash
+$ make clean SUDO=sudo
 ```
 
 With `KUBE_ROOT` it is possible to build from a local kubernetes checkout:

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -59,7 +59,7 @@ Some prerequisites:
 
 
 ```shell
-$ export KUBERNETES_MASTER=http://{the-dcos-host-your-kubernetes-master-is-running-on}/services/kubernetes/api
+$ export KUBERNETES_MASTER=http://{the-dcos-host-your-kubernetes-master-is-running-on}/service/kubernetes/api
 
 $ bin/kubectl get pods --all-namespaces
 NAMESPACE     NAME                READY     STATUS    RESTARTS   AGE

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -14,6 +14,8 @@ $ make push
 
 If you source directory is not clean, this will be reflected in the Docker tag with "dirty" and "unclean".
 
+The `make build` will store the docker image name for a following `make push`. Hence, don't worry about passing all variables again if you customize your build as described above. Moreover, `make push` will ask you whether you really want to push the given docker image.
+
 Optionally the version might be specified:
 
 ```shell

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -26,6 +26,13 @@ Moreover, there are the following variables can be customized via the command li
 ```make
 GIT_URL ?= https://github.com/mesosphere/kubernetes
 DOCKER_ORG ?= mesosphere
+KUBE_ROOT ?=
+```
+
+With `KUBE_ROOT` it is possible to build from a local kubernetes checkout:
+
+```bash
+$ make KUBE_ROOT=~/src/kubernetes
 ```
 
 ## Development and Testing

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -45,6 +45,14 @@ With `KUBE_ROOT` it is possible to build from a local kubernetes checkout:
 $ make KUBE_ROOT=~/src/kubernetes
 ```
 
+## Uploading Github Release Assets
+
+The Makefile can build kubectl tar.gz files for Linux and OSX, and upload those as Github assets to a release:
+
+```bash
+make github-release-assets GITHUB_TOKEN=<github-developer-token>
+```
+
 ## Development and Testing
 
 The Docker container can be run manually outside of a DCOS cluster, e.g.:

--- a/hack/images/dcos/README.md
+++ b/hack/images/dcos/README.md
@@ -53,6 +53,8 @@ The Makefile can build kubectl tar.gz files for Linux and OSX, and upload those 
 make github-release-assets GITHUB_TOKEN=<github-developer-token>
 ```
 
+**Note**: the `GITHUB_TOKEN` requires the `public repo` scope only.
+
 ## Development and Testing
 
 The Docker container can be run manually outside of a DCOS cluster, e.g.:

--- a/hack/images/dcos/bootstrap.sh
+++ b/hack/images/dcos/bootstrap.sh
@@ -84,8 +84,8 @@ echo "* service proxy: $service_proxy"
 etcd_server_port=${ETCD_SERVER_PORT:-4001}
 etcd_server_peer_port=${ETCD_SERVER_PEER_PORT:-4002}
 
-DISABLE_ETCD_SERVER=${DISABLE_ETCD_SERVER:-false}
-if [ "${DISABLE_ETCD_SERVER}" = true ]; then
+ENABLE_ETCD_SERVER=${ENABLE_ETCD_SERVER:-false}
+if [ "${ENABLE_ETCD_SERVER}" != true ]; then
   etcd_server_list=${ETCD_SERVER_LIST:-http://${service_proxy}:${etcd_server_port}}
 else
   etcd_advertise_server_host=${ETCD_ADVERTISE_SERVER_HOST:-127.0.0.1}
@@ -303,7 +303,7 @@ ${apply_uids}
   $(if [ -n "${kube_cluster_domain}" ]; then echo "--cluster-domain=${kube_cluster_domain}"; fi)
 EOF
 
-if [ "$DISABLE_ETCD_SERVER" != true ]; then
+if [ "$ENABLE_ETCD_SERVER" == true ]; then
   prepare_etcd_service
 fi
 

--- a/hack/images/dcos/bootstrap.sh
+++ b/hack/images/dcos/bootstrap.sh
@@ -84,8 +84,8 @@ echo "* service proxy: $service_proxy"
 etcd_server_port=${ETCD_SERVER_PORT:-4001}
 etcd_server_peer_port=${ETCD_SERVER_PEER_PORT:-4002}
 
-: ${ENABLE_ETCD_SERVER="true"}
-if [ "${ENABLE_ETCD_SERVER}" == "false" ]; then
+DISABLE_ETCD_SERVER=${DISABLE_ETCD_SERVER:-false}
+if [ "${DISABLE_ETCD_SERVER}" = true ]; then
   etcd_server_list=${ETCD_SERVER_LIST:-http://${service_proxy}:${etcd_server_port}}
 else
   etcd_advertise_server_host=${ETCD_ADVERTISE_SERVER_HOST:-127.0.0.1}
@@ -303,7 +303,7 @@ ${apply_uids}
   $(if [ -n "${kube_cluster_domain}" ]; then echo "--cluster-domain=${kube_cluster_domain}"; fi)
 EOF
 
-if [ "${ENABLE_ETCD_SERVER}" == "true" ]; then
+if [ "$DISABLE_ETCD_SERVER" != true ]; then
   prepare_etcd_service
 fi
 

--- a/hack/images/dcos/bootstrap.sh
+++ b/hack/images/dcos/bootstrap.sh
@@ -297,7 +297,7 @@ ${apply_uids}
   --proxy-logv=${PROXY_GLOG_v:-${logv}}
   --default-container-cpu-limit=${DEFAULT_CONTAINER_CPU_LMIIT:-0.25}
   --default-container-mem-limit=${DEFAULT_CONTAINER_MEM_LMIIT:-64}
-  --cgroup-prefix=${CGROUP_PREFIX:-/mesos}
+  --executor-cgroup-prefix=${CGROUP_PREFIX:-/mesos}
   $(if [ -n "${K8SM_FAILOVER_TIMEOUT:-}" ]; then echo "--failover-timeout=${K8SM_FAILOVER_TIMEOUT}"; fi)
   $(if [ -n "${kube_cluster_dns}" ]; then echo "--cluster-dns=${kube_cluster_dns}"; fi)
   $(if [ -n "${kube_cluster_domain}" ]; then echo "--cluster-domain=${kube_cluster_domain}"; fi)

--- a/hack/images/dcos/bootstrap.sh
+++ b/hack/images/dcos/bootstrap.sh
@@ -293,6 +293,11 @@ ${apply_uids}
   --mesos-user=${K8SM_MESOS_USER:-root}
   --port=${scheduler_port}
   --v=${SCHEDULER_GLOG_v:-${logv}}
+  --executor-logv=${EXECUTOR_GLOG_v:-${logv}}
+  --proxy-logv=${PROXY_GLOG_v:-${logv}}
+  --default-container-cpu-limit=${DEFAULT_CONTAINER_CPU_LMIIT:-0.25}
+  --default-container-mem-limit=${DEFAULT_CONTAINER_MEM_LMIIT:-64}
+  --cgroup-prefix=${CGROUP_PREFIX:-/mesos}
   $(if [ -n "${K8SM_FAILOVER_TIMEOUT:-}" ]; then echo "--failover-timeout=${K8SM_FAILOVER_TIMEOUT}"; fi)
   $(if [ -n "${kube_cluster_dns}" ]; then echo "--cluster-dns=${kube_cluster_dns}"; fi)
   $(if [ -n "${kube_cluster_domain}" ]; then echo "--cluster-domain=${kube_cluster_domain}"; fi)

--- a/hack/images/dcos/bootstrap.sh
+++ b/hack/images/dcos/bootstrap.sh
@@ -201,7 +201,7 @@ EOF
 
 prepare_kube_dns() {
   kube_cluster_dns=${DNS_SERVER_IP:-10.10.10.10}
-  kube_cluster_domain=${DNS_DOMAIN:-kubernetes.local}
+  kube_cluster_domain=${DNS_DOMAIN:-cluster.local}
   local kube_nameservers=$(cat /etc/resolv.conf|grep -e ^nameserver|head -3|cut -f2 -d' '|sed -e 's/$/:53/g'|xargs echo -n|tr ' ' ,)
   kube_nameservers=${kube_nameservers:-${DNS_NAMESERVERS:-8.8.8.8:53,8.8.4.4:53}}
 


### PR DESCRIPTION
- switch to upstream bulid container instead of our own
- create _build directory and store all build artifacts there
- add release target to Makefile to upload kubectl binaries to a Github release of the GIT_REF name
- rename ENABLE_ETCD_SERVER  -> DISABLE_ETCD_SERVER
- update build README.md to match build process and fix smoke tests
- set cluster.local kube-dns domain, matching upstream's default
- download S6 from Makefile
- avoid re-downloading of anything if it exists in _build