### PR TITLE
K8SM_PROXY_MODE envvar

### DIFF
--- a/images/dcos/bootstrap.sh
+++ b/images/dcos/bootstrap.sh
@@ -317,6 +317,7 @@ ${apply_uids}
   --account-for-pod-resources=${SCHEDULER_ACCOUNT_FOR_POD_RESOURCES:-true}
   --mesos-executor-cpus=${SCHEDULER_MESOS_EXECUTOR_CPUS:-0.25}
   --mesos-executor-mem=${SCHEDULER_MESOS_EXECUTOR_MEM:-128}
+  --proxy-mode=${K8SM_PROXY_MODE:-userspace}
   $(if [ -n "${K8SM_FAILOVER_TIMEOUT:-}" ]; then echo "--failover-timeout=${K8SM_FAILOVER_TIMEOUT}"; fi)
   $(if [ -n "${kube_cluster_dns}" ]; then echo "--cluster-dns=${kube_cluster_dns}"; fi)
   $(if [ -n "${kube_cluster_domain}" ]; then echo "--cluster-domain=${kube_cluster_domain}"; fi)


### PR DESCRIPTION
added K8SM_PROXY_MODE envvar that controls kube-proxys iptables vs userspace --proxy-mode flag