### PR TITLE
Fixes for make build

### DIFF
--- a/images/dcos/Dockerfile
+++ b/images/dcos/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.2
 MAINTAINER Mesosphere <support@mesosphere.com>
 
 RUN apk --update add nginx curl ca-certificates && \
-    curl -Ls https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk > /tmp/glibc-2.21-r2.apk && \
+    curl -Ls https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.21-r2/glibc-2.21-r2.apk > /tmp/glibc-2.21-r2.apk && \
     apk add --allow-untrusted /tmp/glibc-2.21-r2.apk && \
     rm -rf /tmp/glibc-2.21-r2.apk /var/cache/apk/*
 

--- a/images/dcos/Makefile
+++ b/images/dcos/Makefile
@@ -16,6 +16,9 @@ POSTFIX    ?= $(call LOAD_OR_DEFAULT,POSTFIX,-alpha)
 # NOTE: Do not persist the VERSION. It must be re-computed on every make run.
 GIT_REF_MINOR = $(lastword $(subst -, ,$(GIT_REF)))
 GIT_REF_MAJOR = $(firstword $(subst -, ,$(GIT_REF)))
+ifeq ($(USER),)
+        USER := nobody
+endif
 ifneq ($(wildcard $(BUILD_DIR)),)
 	UNCLEAN_INFIX := -unclean
 endif

--- a/images/dcos/Makefile
+++ b/images/dcos/Makefile
@@ -16,12 +16,14 @@ POSTFIX    ?= $(call LOAD_OR_DEFAULT,POSTFIX,-alpha)
 # NOTE: Do not persist the VERSION. It must be re-computed on every make run.
 GIT_REF_MINOR = $(lastword $(subst -, ,$(GIT_REF)))
 GIT_REF_MAJOR = $(firstword $(subst -, ,$(GIT_REF)))
+ifeq ($(USER),)
+        USER := nobody
+endif
 ifneq ($(wildcard $(BUILD_DIR)),)
 	UNCLEAN_INFIX := -unclean
-	UNCLEAN_PREFIX := $(USER)-
 endif
 ifeq ($(KUBE_ROOT),)
-	VERSION := $(UNCLEAN_PREFIX)$(shell git describe --match $(GIT_REF_MAJOR) --always --tags --dirty)$(UNCLEAN_INFIX)-$(GIT_REF_MINOR)
+	VERSION := $(USER)-$(shell git describe --match $(GIT_REF_MAJOR) --always --tags --dirty)$(UNCLEAN_INFIX)-$(GIT_REF_MINOR)
 else
 	VERSION := $(USER)-$(GIT_REF)-dev
 endif

--- a/images/dcos/Makefile
+++ b/images/dcos/Makefile
@@ -29,7 +29,7 @@ endif
 # compute the Docker image tag
 # NOTE: As VERSION, do not persist DOCKER_IMAGE
 DOCKER_REPO = $(DOCKER_ORG)/kubernetes
-DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)$(POSTFIX)
+DOCKER_IMAGE = $(DOCKER_REPO)$(VERSION)$(POSTFIX)
 DOCKER_IMAGE_FILE = $(BUILD_DIR)/built-docker-image
 
 # kubernetes binaries distributed in the Docker container

--- a/images/dcos/Makefile
+++ b/images/dcos/Makefile
@@ -23,7 +23,7 @@ ifneq ($(wildcard $(BUILD_DIR)),)
 	UNCLEAN_INFIX := -unclean
 endif
 ifeq ($(KUBE_ROOT),)
-	VERSION := $(USER)$(shell git describe --match $(GIT_REF_MAJOR) --always --tags --dirty)$(UNCLEAN_INFIX)-$(GIT_REF_MINOR)
+	VERSION := $(USER)-$(shell git describe --match $(GIT_REF_MAJOR) --always --tags --dirty)$(UNCLEAN_INFIX)-$(GIT_REF_MINOR)
 else
 	VERSION := $(USER)-$(GIT_REF)-dev
 endif

--- a/images/dcos/Makefile
+++ b/images/dcos/Makefile
@@ -18,10 +18,9 @@ GIT_REF_MINOR = $(lastword $(subst -, ,$(GIT_REF)))
 GIT_REF_MAJOR = $(firstword $(subst -, ,$(GIT_REF)))
 ifneq ($(wildcard $(BUILD_DIR)),)
 	UNCLEAN_INFIX := -unclean
-	UNCLEAN_PREFIX := $(USER)-
 endif
 ifeq ($(KUBE_ROOT),)
-	VERSION := $(UNCLEAN_PREFIX)$(shell git describe --match $(GIT_REF_MAJOR) --always --tags --dirty)$(UNCLEAN_INFIX)-$(GIT_REF_MINOR)
+	VERSION := $(USER)$(shell git describe --match $(GIT_REF_MAJOR) --always --tags --dirty)$(UNCLEAN_INFIX)-$(GIT_REF_MINOR)
 else
 	VERSION := $(USER)-$(GIT_REF)-dev
 endif
@@ -29,7 +28,7 @@ endif
 # compute the Docker image tag
 # NOTE: As VERSION, do not persist DOCKER_IMAGE
 DOCKER_REPO = $(DOCKER_ORG)/kubernetes
-DOCKER_IMAGE = $(DOCKER_REPO)$(VERSION)$(POSTFIX)
+DOCKER_IMAGE = $(DOCKER_REPO):$(VERSION)$(POSTFIX)
 DOCKER_IMAGE_FILE = $(BUILD_DIR)/built-docker-image
 
 # kubernetes binaries distributed in the Docker container


### PR DESCRIPTION
- Fix docker tag in Makefile (removed ':', because of error: 'invalid value for flag --tag:').
- Fix link to glibc-2.21-r2.apk (original one: 'https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk' does not work anymore).
